### PR TITLE
Fix login workflow: prevent misleading client processing on redirect

### DIFF
--- a/libs/oarng/src/lib/auth/auth.service.ts
+++ b/libs/oarng/src/lib/auth/auth.service.ts
@@ -210,7 +210,7 @@ export class OARAuthenticationService extends AuthenticationService {
             catchError((e) => {
                 console.error("Credentials not available (status = "+e.status+")");
                 if (e.status && e.status == 401) 
-                    return this.handleUnauthenticated((nologin) ? undefined : returnURL);
+                    return this.handleUnauthenticated(!nologin, returnURL);
                 return this.handleFetchError(e);
             })
         );
@@ -243,8 +243,8 @@ export class OARAuthenticationService extends AuthenticationService {
      *                       URL to return to after completing the process.
      * @return Observable<Credentials> 
      */
-    handleUnauthenticated(authReturnURL?: string) : Observable<Credentials> {
-        if (authReturnURL) 
+    handleUnauthenticated(dologin: boolean, authReturnURL?: string) : Observable<Credentials> {
+        if (dologin) 
             // this will cause the browser to redirect to login service,
             // terminating this application
             if (this.loginUser(authReturnURL))

--- a/libs/oarng/src/lib/auth/auth.service.ts
+++ b/libs/oarng/src/lib/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, of, map, tap, catchError, throwError, Subscriber } from 'rxjs';
+import { Observable, of, map, tap, catchError, throwError, Subscriber, EMPTY } from 'rxjs';
 
 import { AuthInfo, UserDetails, Credentials, MOCK_CREDENTIALS, messageToCredentials, deepCopy } from './auth';
 import { Configuration, ConfigurationService } from '../config/config.module';
@@ -84,8 +84,10 @@ export abstract class AuthenticationService {
      * this application after the login process is complete.  
      * @param returnURL   the URL to redirect the browser to after a successful login to return to 
      *                    to the application.  If not provided, window.location.href will be used. 
+     * @return boolean  True if the implementation issued a browser redirect; False, otherwise. 
+     *                  This allows the caller to halt operations if redirection is imminent.  
      */
-    public abstract loginUser(returnURL?: string): void;
+    public abstract loginUser(returnURL?: string): boolean;
 }
 
 /**
@@ -197,12 +199,15 @@ export class OARAuthenticationService extends AuthenticationService {
     public fetchCredentials(nologin: boolean = false, returnURL?: string): Observable<Credentials> {
         return this.fetchCredentialsFrom(this.endpoint).pipe(
             tap((c) => {
+                console.log("Credentials fetched for "+c.userId);
                 if (!nologin && ! AuthenticationService.authenticatedCreds(c))
                     // this will cause the browser to redirect to login service,
                     // terminating this application
-                    this.loginUser(returnURL);
+                    if (this.loginUser(returnURL))
+                        return EMPTY;
             }),
             catchError((e) => {
+                console.error("Credentials not available (status = "+e.status+")");
                 if (e.status && e.status == 401) 
                     return this.handleUnauthenticated((nologin) ? undefined : returnURL);
                 return this.handleFetchError(e);
@@ -241,7 +246,8 @@ export class OARAuthenticationService extends AuthenticationService {
         if (authReturnURL) 
             // this will cause the browser to redirect to login service,
             // terminating this application
-            this.loginUser(authReturnURL);
+            if (this.loginUser(authReturnURL))
+                return EMPTY;
         return of(deepCopy(anonymousCreds));
     }
 
@@ -281,11 +287,14 @@ export class OARAuthenticationService extends AuthenticationService {
      * @param returnURL the URL that the login service should redirect to after a successful login
      *                  to return the browser to this application.  If not provided, the value
      *                  of window.location.href will be used.  
+     * @return boolean  True if the implementation issued a browser redirect; False, otherwise. 
+     *                  This allows the caller to halt operations if redirection is imminent.  
      */
-    public loginUser(returnURL?: string): void {
+    public loginUser(returnURL?: string): boolean {
         let loginURL = this.getLoginURL(returnURL);
         console.log("To login user, redirecting to " + loginURL);
         window.location.assign(loginURL);
+        return True;
     }
 }
 

--- a/libs/oarng/src/lib/auth/auth.ts
+++ b/libs/oarng/src/lib/auth/auth.ts
@@ -132,7 +132,8 @@ export interface AuthInfo {
  */
 export function messageToCredentials(message: AuthInfo) : Credentials {
     if (! message.userDetails)
-        throw new Error("Unexpected authentication service response (missing userDetails): "+message);
+        throw new Error("Unexpected authentication service response (missing userDetails): "+
+                        JSON.stringify(message));
     let out : Credentials = {
         userId: message.userDetails.userId,
         userAttributes: deepCopy(message.userDetails)


### PR DESCRIPTION
This PR addresses a problem in the RPA approve client that would display an error message to the user just before redirecting the browser to the login service.  This was due to the asynchronous nature of requesting credentials, determining whether authentication is needed, and redirecting the browser.  This was corrected by short-circuiting the asynchronous processing after issuing the redirect.