### PR TITLE
StaffServiceService: add getPersonByUserName()

### DIFF
--- a/libs/oarng/src/lib/staffdir/staffdir.service.spec.ts
+++ b/libs/oarng/src/lib/staffdir/staffdir.service.spec.ts
@@ -75,6 +75,23 @@ describe('StaffServiceService', () => {
         expect(person).toEqual(pdata);
     });
 
+    it('getPersonByUserName()', async () => {
+        const pdata = {
+            peopleID: 3,
+            lastName: "Cranston",
+            firstName: "Gurn",
+            orcid: "0000",
+            nistUsername: "grc0"
+        };
+        const svcpromise = service.getPersonByUserName("grc0").toPromise();
+        const req = httpMock.expectOne(svcep+"/People?with_nistUsername="+pdata.nistUsername);
+        expect(req.request.method).toBe('GET');
+        req.flush([pdata]);
+
+        const person = await svcpromise;
+        expect(person).toEqual(pdata);
+    });
+
     it('getPeopleIndexFor()', async () => {
         const pdata = {
             peopleID: 3,

--- a/libs/oarng/src/lib/staffdir/staffdir.service.ts
+++ b/libs/oarng/src/lib/staffdir/staffdir.service.ts
@@ -290,6 +290,31 @@ export class StaffDirectoryService {
     }
 
     /**
+     * return the metadata describing a staff person given its ORCID identifier or null 
+     * if the identifier is not found.
+     */
+    public getPersonByUserName(username: string) : Observable<anyobj|null> {
+        let url = StaffDirectoryService.PEOPLE_EP + "?with_nistUsername=" + username
+        return this._get(url).pipe(
+            map<any, anyobj>((r) => {
+                if (r instanceof Array) {
+                    if (r.length > 0)
+                        return r[0];
+                    return null;
+                }
+
+                let msg = "Unexpected response from staff service: not an array"
+                console.error(msg);
+                throw new Error(msg);
+            }),
+            catchError((e) => {
+                this._handleHTTPError(e);
+                throw "Unhandled error: "+e;
+            })
+        );
+    }
+
+    /**
      * return an index for person records that match a given prompt.  The items in the index
      * reference records where the last name or first name of the person starts with the 
      * prompt string.  


### PR DESCRIPTION
This adds a function to the `StaffServiceService` that resolves a NIST enterprise user name to a Person record; it is called `getPersonByUserName()`.  This required no change to the backend people service in [oar-pdr-py](https://github.com/usnistgov/oar-pdr-py) and, thus, works the current version of the DBIO backend or standalone `peopleservice`.

