### PR TITLE
Feature/permission manager

### DIFF
--- a/libs/oarng/jest.config.js
+++ b/libs/oarng/jest.config.js
@@ -4,5 +4,10 @@ module.exports = {
     moduleNameMapper: {
         "^lodash-es$": "lodash"
     },
-    globalSetup: 'jest-preset-angular/global-setup'
+    globalSetup: 'jest-preset-angular/global-setup',
+    globals: {
+        'ts-jest': {
+            tsconfig: '<rootDir>/tsconfig.spec.json'
+        }
+    }
 };

--- a/libs/oarng/package.json
+++ b/libs/oarng/package.json
@@ -4,6 +4,7 @@
     "peerDependencies": {
         "@angular/common": "^18.2.13",
         "@angular/core": "^18.2.13",
+        "@angular/material": "^18.2.13",
         "ng-sidebar": "^9.1.1",
         "primeflex": "^3.3.1",
         "primeicons": "^7.0.0",

--- a/libs/oarng/src/lib/groups/confirm-dialog.component.ts
+++ b/libs/oarng/src/lib/groups/confirm-dialog.component.ts
@@ -1,0 +1,64 @@
+import { Component, inject } from '@angular/core'
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog'
+import { MatButtonModule } from '@angular/material/button'
+import { CommonModule } from '@angular/common'
+
+export interface ConfirmDialogData {
+  title: string
+  body: string
+  items?: string[]
+  section?: string
+  sectionItems?: string[]
+  confirmLabel?: string
+  cancelLabel?: string
+  isDestructive?: boolean
+}
+
+@Component({
+  selector: 'oarng-confirm-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+    <mat-dialog-content class="cd-content">
+      <p class="cd-body">{{ data.body }}</p>
+      @if (data.items?.length) {
+        <ul class="cd-list">
+          @for (item of data.items; track item) {
+            <li>{{ item }}</li>
+          }
+        </ul>
+      }
+      @if (data.section && data.sectionItems?.length) {
+        <p class="cd-section-label">{{ data.section }}</p>
+        <ul class="cd-list cd-list--secondary">
+          @for (item of (data.sectionItems ?? []); track item) {
+            <li>{{ item }}</li>
+          }
+        </ul>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button [mat-dialog-close]="false">
+        {{ data.cancelLabel || 'Cancel' }}
+      </button>
+      <button mat-flat-button
+              [color]="data.isDestructive ? 'warn' : 'primary'"
+              [mat-dialog-close]="true">
+        {{ data.confirmLabel || 'Confirm' }}
+      </button>
+    </mat-dialog-actions>
+  `,
+  styles: [`
+    .cd-content { min-width: 320px; max-width: 480px; }
+    .cd-body { margin: 0 0 0.5rem; }
+    .cd-list { margin: 0.25rem 0 0.75rem 1.25rem; padding: 0; font-size: 0.9rem; }
+    .cd-list--secondary { opacity: 0.75; font-size: 0.85rem; }
+    .cd-section-label { margin: 0.25rem 0 0.1rem; font-size: 0.8rem; font-weight: 500;
+                        text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.55; }
+  `]
+})
+export class ConfirmDialogComponent {
+  data = inject<ConfirmDialogData>(MAT_DIALOG_DATA)
+  ref = inject(MatDialogRef<ConfirmDialogComponent>)
+}

--- a/libs/oarng/src/lib/groups/group.types.ts
+++ b/libs/oarng/src/lib/groups/group.types.ts
@@ -1,0 +1,15 @@
+export interface Group {
+  id: string
+  name: string
+  owner: string
+  members: string[]
+}
+
+export type AclPerm = 'read' | 'write' | 'admin' | 'delete'
+
+export interface Acls {
+  read: string[]
+  write: string[]
+  admin: string[]
+  delete: string[]
+}

--- a/libs/oarng/src/lib/groups/group.types.ts
+++ b/libs/oarng/src/lib/groups/group.types.ts
@@ -13,8 +13,8 @@ export interface RecordRef {
 export type AclPerm = 'read' | 'write' | 'admin' | 'delete'
 
 export interface Acls {
-  read: string[]
-  write: string[]
-  admin: string[]
-  delete: string[]
+  read?: string[]
+  write?: string[]
+  admin?: string[]
+  delete?: string[]
 }

--- a/libs/oarng/src/lib/groups/group.types.ts
+++ b/libs/oarng/src/lib/groups/group.types.ts
@@ -5,6 +5,11 @@ export interface Group {
   members: string[]
 }
 
+export interface RecordRef {
+  id: string
+  apiBase: string
+}
+
 export type AclPerm = 'read' | 'write' | 'admin' | 'delete'
 
 export interface Acls {

--- a/libs/oarng/src/lib/groups/groups-auth.token.ts
+++ b/libs/oarng/src/lib/groups/groups-auth.token.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core'
+
+/**
+ * Provide a function that returns the current Bearer token string.
+ * In the portal: { provide: GROUPS_AUTH_TOKEN, useFactory: (c: CredentialsService) => () => c.token(), deps: [CredentialsService] }
+ */
+export const GROUPS_AUTH_TOKEN = new InjectionToken<() => string>('GROUPS_AUTH_TOKEN')

--- a/libs/oarng/src/lib/groups/groups.module.ts
+++ b/libs/oarng/src/lib/groups/groups.module.ts
@@ -1,11 +1,26 @@
 import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { FormsModule } from '@angular/forms'
+import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
+import { MatDividerModule } from '@angular/material/divider'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatIconModule } from '@angular/material/icon'
+import { MatInputModule } from '@angular/material/input'
 import { PermissionManagerComponent } from './permission-manager/permission-manager.component'
 
 @NgModule({
   declarations: [PermissionManagerComponent],
-  imports: [CommonModule, MatCardModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+  ],
   exports: [PermissionManagerComponent]
 })
 export class GroupsModule {}

--- a/libs/oarng/src/lib/groups/groups.module.ts
+++ b/libs/oarng/src/lib/groups/groups.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { MatCardModule } from '@angular/material/card'
+import { PermissionManagerComponent } from './permission-manager/permission-manager.component'
+
+@NgModule({
+  declarations: [PermissionManagerComponent],
+  imports: [CommonModule, MatCardModule],
+  exports: [PermissionManagerComponent]
+})
+export class GroupsModule {}

--- a/libs/oarng/src/lib/groups/groups.module.ts
+++ b/libs/oarng/src/lib/groups/groups.module.ts
@@ -11,6 +11,7 @@ import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { MatMenuModule } from '@angular/material/menu'
 import { MatSelectModule } from '@angular/material/select'
 import { PermissionManagerComponent } from './permission-manager/permission-manager.component'
 import { ConfirmDialogComponent } from './confirm-dialog.component'
@@ -29,6 +30,7 @@ import { ConfirmDialogComponent } from './confirm-dialog.component'
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatMenuModule,
     MatProgressSpinnerModule,
     MatSelectModule,
     ConfirmDialogComponent,

--- a/libs/oarng/src/lib/groups/groups.module.ts
+++ b/libs/oarng/src/lib/groups/groups.module.ts
@@ -3,10 +3,12 @@ import { CommonModule } from '@angular/common'
 import { FormsModule } from '@angular/forms'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
+import { MatChipsModule } from '@angular/material/chips'
 import { MatDividerModule } from '@angular/material/divider'
 import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { PermissionManagerComponent } from './permission-manager/permission-manager.component'
 
 @NgModule({
@@ -16,10 +18,12 @@ import { PermissionManagerComponent } from './permission-manager/permission-mana
     FormsModule,
     MatButtonModule,
     MatCardModule,
+    MatChipsModule,
     MatDividerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatProgressSpinnerModule,
   ],
   exports: [PermissionManagerComponent]
 })

--- a/libs/oarng/src/lib/groups/groups.module.ts
+++ b/libs/oarng/src/lib/groups/groups.module.ts
@@ -1,29 +1,37 @@
 import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { FormsModule } from '@angular/forms'
+import { MatAutocompleteModule } from '@angular/material/autocomplete'
 import { MatButtonModule } from '@angular/material/button'
 import { MatCardModule } from '@angular/material/card'
 import { MatChipsModule } from '@angular/material/chips'
+import { MatDialogModule } from '@angular/material/dialog'
 import { MatDividerModule } from '@angular/material/divider'
 import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatIconModule } from '@angular/material/icon'
 import { MatInputModule } from '@angular/material/input'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { MatSelectModule } from '@angular/material/select'
 import { PermissionManagerComponent } from './permission-manager/permission-manager.component'
+import { ConfirmDialogComponent } from './confirm-dialog.component'
 
 @NgModule({
   declarations: [PermissionManagerComponent],
   imports: [
     CommonModule,
     FormsModule,
+    MatAutocompleteModule,
     MatButtonModule,
     MatCardModule,
     MatChipsModule,
+    MatDialogModule,
     MatDividerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
     MatProgressSpinnerModule,
+    MatSelectModule,
+    ConfirmDialogComponent,
   ],
   exports: [PermissionManagerComponent]
 })

--- a/libs/oarng/src/lib/groups/groups.service.spec.ts
+++ b/libs/oarng/src/lib/groups/groups.service.spec.ts
@@ -1,0 +1,174 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { GroupsService } from './groups.service'
+import { ConfigurationService } from '../config/config.service'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+import { Group } from './group.types'
+
+const BASE = 'https://api.example.com/midas/groups/grp0'
+const GROUP: Group = { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: ['bob'] }
+
+function makeTestBed(token?: string): void {
+  const providers: any[] = [
+    GroupsService,
+    { provide: ConfigurationService, useValue: { getConfig: () => ({ groupAPI: BASE }) } },
+  ]
+  if (token) providers.push({ provide: GROUPS_AUTH_TOKEN, useValue: () => token })
+  TestBed.configureTestingModule({ imports: [HttpClientTestingModule], providers })
+}
+
+describe('GroupsService — HTTP methods and URL construction', () => {
+  let svc: GroupsService
+  let http: HttpTestingController
+
+  beforeEach(() => {
+    makeTestBed()
+    svc = TestBed.inject(GroupsService)
+    http = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => http.verify())
+
+  describe('getGroups()', () => {
+    it('issues GET to the base URL', () => {
+      svc.getGroups().subscribe()
+      const req = http.expectOne(BASE)
+      expect(req.request.method).toBe('GET')
+      req.flush([GROUP])
+    })
+  })
+
+  describe('createGroup()', () => {
+    it('issues POST to the base URL', () => {
+      svc.createGroup('My Team').subscribe()
+      const req = http.expectOne(BASE)
+      expect(req.request.method).toBe('POST')
+      req.flush(GROUP)
+    })
+
+    it('sends { name } as the request body', () => {
+      svc.createGroup('My Team').subscribe()
+      const req = http.expectOne(BASE)
+      expect(req.request.body).toEqual({ name: 'My Team' })
+      req.flush(GROUP)
+    })
+  })
+
+  describe('deleteGroup()', () => {
+    it('issues DELETE to /{shoulder}/{groupId}', () => {
+      svc.deleteGroup('grp0:alice:team').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team`)
+      expect(req.request.method).toBe('DELETE')
+      req.flush('Group deleted', { headers: { 'Content-Type': 'text/plain' } })
+    })
+  })
+
+  describe('addMember()', () => {
+    it('issues POST to /{shoulder}/{groupId}', () => {
+      svc.addMember('grp0:alice:team', 'bob').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team`)
+      expect(req.request.method).toBe('POST')
+      req.flush(['bob'])
+    })
+
+    it('sends JSON-encoded memberId as body', () => {
+      svc.addMember('grp0:alice:team', 'bob').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team`)
+      expect(req.request.body).toBe('"bob"')
+      req.flush(['bob'])
+    })
+
+    it('sets Content-Type: application/json', () => {
+      svc.addMember('grp0:alice:team', 'bob').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team`)
+      expect(req.request.headers.get('Content-Type')).toBe('application/json')
+      req.flush(['bob'])
+    })
+  })
+
+  describe('removeMember()', () => {
+    it('issues DELETE to /{shoulder}/{groupId}/{memberId}', () => {
+      svc.removeMember('grp0:alice:team', 'bob').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team/bob`)
+      expect(req.request.method).toBe('DELETE')
+      req.flush('Removed bob from group', { headers: { 'Content-Type': 'text/plain' } })
+    })
+
+    it('URL-encodes memberId containing special characters', () => {
+      svc.removeMember('grp0:alice:team', 'user@nist.gov').subscribe()
+      const req = http.expectOne(`${BASE}/grp0/grp0:alice:team/user%40nist.gov`)
+      req.flush('removed', { headers: { 'Content-Type': 'text/plain' } })
+    })
+  })
+})
+
+describe('GroupsService — groupUrl shoulder routing', () => {
+  let svc: GroupsService
+  let http: HttpTestingController
+
+  beforeEach(() => {
+    makeTestBed()
+    svc = TestBed.inject(GroupsService)
+    http = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => http.verify())
+
+  it('routes grp0:{owner}:{name} to /{base}/grp0/{groupId}', () => {
+    svc.deleteGroup('grp0:alice:myteam').subscribe()
+    http.expectOne(`${BASE}/grp0/grp0:alice:myteam`).flush('deleted', {
+      headers: { 'Content-Type': 'text/plain' }
+    })
+  })
+
+  it('uses the full groupId as shoulder when there is no colon', () => {
+    svc.deleteGroup('orphanGroup').subscribe()
+    // fix: when there is no colon, fall back to grp0 shoulder
+    http.expectOne(`${BASE}/grp0/orphanGroup`).flush('deleted', {
+      headers: { 'Content-Type': 'text/plain' }
+    })
+  })
+
+  it('falls back to grp0 shoulder when groupId starts with a colon', () => {
+    svc.deleteGroup(':headless').subscribe()
+    http.expectOne(`${BASE}/grp0/:headless`).flush('deleted', {
+      headers: { 'Content-Type': 'text/plain' }
+    })
+  })
+
+  it('extracts the correct shoulder from a non-grp0 prefix', () => {
+    svc.deleteGroup('grp1:alice:team').subscribe()
+    http.expectOne(`${BASE}/grp1/grp1:alice:team`).flush('deleted', {
+      headers: { 'Content-Type': 'text/plain' }
+    })
+  })
+})
+
+describe('GroupsService — Authorization header', () => {
+  let svc: GroupsService
+  let http: HttpTestingController
+
+  afterEach(() => http.verify())
+
+  it('sets Authorization: Bearer {token} when token is provided', () => {
+    makeTestBed('group-secret')
+    svc = TestBed.inject(GroupsService)
+    http = TestBed.inject(HttpTestingController)
+
+    svc.getGroups().subscribe()
+    const req = http.expectOne(BASE)
+    expect(req.request.headers.get('Authorization')).toBe('Bearer group-secret')
+    req.flush([])
+  })
+
+  it('omits Authorization header when no token is provided', () => {
+    makeTestBed()
+    svc = TestBed.inject(GroupsService)
+    http = TestBed.inject(HttpTestingController)
+
+    svc.getGroups().subscribe()
+    const req = http.expectOne(BASE)
+    expect(req.request.headers.has('Authorization')).toBe(false)
+    req.flush([])
+  })
+})

--- a/libs/oarng/src/lib/groups/groups.service.spec.ts
+++ b/libs/oarng/src/lib/groups/groups.service.spec.ts
@@ -5,7 +5,7 @@ import { ConfigurationService } from '../config/config.service'
 import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
 import { Group } from './group.types'
 
-const BASE = 'https://api.example.com/midas/groups/grp0'
+const BASE = 'https://api.example.com/midas/groups'
 const GROUP: Group = { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: ['bob'] }
 
 function makeTestBed(token?: string): void {

--- a/libs/oarng/src/lib/groups/groups.service.ts
+++ b/libs/oarng/src/lib/groups/groups.service.ts
@@ -42,6 +42,7 @@ export class GroupsService {
   addMember(groupId: string, memberId: string): Observable<string[]> {
     return this.http.post<string[]>(
       this.groupUrl(groupId),
+      // get_json_body() expects valid JSON; a bare string is not valid JSON, so encode it as a JSON string literal
       JSON.stringify(memberId),
       { headers: this.headers.set('Content-Type', 'application/json') }
     )

--- a/libs/oarng/src/lib/groups/groups.service.ts
+++ b/libs/oarng/src/lib/groups/groups.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, inject } from '@angular/core'
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { ConfigurationService } from '../config/config.service'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+import { Group } from './group.types'
+
+@Injectable({ providedIn: 'root' })
+export class GroupsService {
+  private http = inject(HttpClient)
+  private configService = inject(ConfigurationService)
+  private getToken = inject(GROUPS_AUTH_TOKEN, { optional: true }) ?? (() => '')
+
+  private get base(): string {
+    return (this.configService.getConfig()['groupAPI'] as string ?? '').replace(/\/$/, '')
+  }
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+  }
+
+  getGroups(): Observable<Group[]> {
+    return this.http.get<Group[]>(this.base, { headers: this.headers })
+  }
+
+  // POST body: { name } — backend extracts owner from JWT
+  createGroup(name: string): Observable<Group> {
+    return this.http.post<Group>(this.base, { name }, { headers: this.headers })
+  }
+
+  deleteGroup(groupId: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${groupId}`, { headers: this.headers })
+  }
+
+  // Backend: POST /{groupId} with body as the member ID string directly
+  addMember(groupId: string, memberId: string): Observable<Group> {
+    return this.http.post<Group>(
+      `${this.base}/${groupId}`,
+      memberId,
+      { headers: this.headers.set('Content-Type', 'application/json') }
+    )
+  }
+
+  // Backend: DELETE /{groupId}/{memberId}
+  removeMember(groupId: string, memberId: string): Observable<void> {
+    return this.http.delete<void>(
+      `${this.base}/${groupId}/${encodeURIComponent(memberId)}`,
+      { headers: this.headers }
+    )
+  }
+}

--- a/libs/oarng/src/lib/groups/groups.service.ts
+++ b/libs/oarng/src/lib/groups/groups.service.ts
@@ -16,7 +16,9 @@ export class GroupsService {
   }
 
   private get headers(): HttpHeaders {
-    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+    const token = this.getToken()
+    const h = new HttpHeaders()
+    return token ? h.set('Authorization', `Bearer ${token}`) : h
   }
 
   getGroups(): Observable<Group[]> {
@@ -28,24 +30,36 @@ export class GroupsService {
     return this.http.post<Group>(this.base, { name }, { headers: this.headers })
   }
 
-  deleteGroup(groupId: string): Observable<void> {
-    return this.http.delete<void>(`${this.base}/${groupId}`, { headers: this.headers })
+  // Backend returns text/plain ("Group deleted"), not JSON
+  deleteGroup(groupId: string): Observable<string> {
+    return this.http.delete(
+      this.groupUrl(groupId),
+      { headers: this.headers, responseType: 'text' }
+    )
   }
 
-  // Backend: POST /{groupId} with body as the member ID string directly
-  addMember(groupId: string, memberId: string): Observable<Group> {
-    return this.http.post<Group>(
-      `${this.base}/${groupId}`,
-      memberId,
+  // Backend: POST /{shoulder}/{groupId} — returns the updated members array, not the full group
+  addMember(groupId: string, memberId: string): Observable<string[]> {
+    return this.http.post<string[]>(
+      this.groupUrl(groupId),
+      JSON.stringify(memberId),
       { headers: this.headers.set('Content-Type', 'application/json') }
     )
   }
 
-  // Backend: DELETE /{groupId}/{memberId}
-  removeMember(groupId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(
-      `${this.base}/${groupId}/${encodeURIComponent(memberId)}`,
-      { headers: this.headers }
+  // Backend returns text/plain ("Removed … from group …"), not JSON
+  removeMember(groupId: string, memberId: string): Observable<string> {
+    return this.http.delete(
+      `${this.groupUrl(groupId)}/${encodeURIComponent(memberId)}`,
+      { headers: this.headers, responseType: 'text' }
     )
+  }
+
+  // Group IDs are "{shoulder}:{owner}:{name}" — backend requires /{shoulder}/{groupId} routing.
+  // colonIdx > 0 guards against IDs with no prefix (fall back to grp0).
+  private groupUrl(groupId: string): string {
+    const colonIdx = groupId.indexOf(':')
+    const shoulder = colonIdx > 0 ? groupId.substring(0, colonIdx) : 'grp0'
+    return `${this.base}/${shoulder}/${groupId}`
   }
 }

--- a/libs/oarng/src/lib/groups/groups.service.ts
+++ b/libs/oarng/src/lib/groups/groups.service.ts
@@ -16,7 +16,9 @@ export class GroupsService {
   }
 
   private get headers(): HttpHeaders {
-    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+    const token = this.getToken()
+    const h = new HttpHeaders()
+    return token ? h.set('Authorization', `Bearer ${token}`) : h
   }
 
   getGroups(): Observable<Group[]> {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -126,181 +126,203 @@
           <p class="pm-empty-state">Select a record to load its permissions.</p>
         } @else {
 
-          <!-- Read-only summary: who has what level at a glance -->
-          <div class="perm-summary" aria-label="Permission summary">
-            <div class="perm-summary-row">
-              <span class="perm-summary-label perm-summary-label--admin">Admin</span>
-              <span class="perm-summary-pills">
-                @if (subjectsByLevel().admin.length === 0) {
-                  <span class="perm-summary-empty" aria-label="No admin access">—</span>
-                }
+          <!-- Chips grouped by permission level -->
+          <div class="pm-levels" aria-label="Permissions by level">
+
+            <!-- Admin -->
+            <div class="pm-level-section">
+              <span class="pm-level-header pm-level-header--admin">Admin</span>
+              <div class="pm-chips">
                 @for (s of subjectsByLevel().admin; track s) {
-                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                  <div class="pm-chip pm-chip--admin">
+                    <button class="pm-chip-label"
+                            [matMenuTriggerFor]="adminMenu"
+                            [attr.aria-label]="'Change level for ' + (subjectLabels()[s] || s)">
+                      <mat-icon class="pm-chip-icon" aria-hidden="true">{{ isGroup(s) ? 'corporate_fare' : 'person' }}</mat-icon>
+                      {{ subjectLabels()[s] || s }}
+                    </button>
+                    <button class="pm-chip-remove"
+                            (click)="confirmRemoveSubject(s)"
+                            [attr.aria-label]="'Remove ' + (subjectLabels()[s] || s)">×</button>
+                    <mat-menu #adminMenu>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'admin', 'update')">Change to Update</button>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'admin', 'view')">Change to View</button>
+                    </mat-menu>
+                  </div>
                 }
-              </span>
+                @if (subjectsByLevel().admin.length === 0) {
+                  <span class="pm-chips-empty" aria-label="No admin access">—</span>
+                }
+              </div>
             </div>
-            <div class="perm-summary-row">
-              <span class="perm-summary-label perm-summary-label--update">Update</span>
-              <span class="perm-summary-pills">
-                @if (subjectsByLevel().update.length === 0) {
-                  <span class="perm-summary-empty" aria-label="No update access">—</span>
-                }
+
+            <!-- Update -->
+            <div class="pm-level-section">
+              <span class="pm-level-header pm-level-header--update">Update</span>
+              <div class="pm-chips">
                 @for (s of subjectsByLevel().update; track s) {
-                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                  <div class="pm-chip pm-chip--update">
+                    <button class="pm-chip-label"
+                            [matMenuTriggerFor]="updateMenu"
+                            [attr.aria-label]="'Change level for ' + (subjectLabels()[s] || s)">
+                      <mat-icon class="pm-chip-icon" aria-hidden="true">{{ isGroup(s) ? 'corporate_fare' : 'person' }}</mat-icon>
+                      {{ subjectLabels()[s] || s }}
+                    </button>
+                    <button class="pm-chip-remove"
+                            (click)="confirmRemoveSubject(s)"
+                            [attr.aria-label]="'Remove ' + (subjectLabels()[s] || s)">×</button>
+                    <mat-menu #updateMenu>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'update', 'admin')">Change to Admin</button>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'update', 'view')">Change to View</button>
+                    </mat-menu>
+                  </div>
                 }
-              </span>
+                @if (subjectsByLevel().update.length === 0) {
+                  <span class="pm-chips-empty" aria-label="No update access">—</span>
+                }
+              </div>
             </div>
-            <div class="perm-summary-row">
-              <span class="perm-summary-label perm-summary-label--view">View</span>
-              <span class="perm-summary-pills">
-                @if (subjectsByLevel().view.length === 0) {
-                  <span class="perm-summary-empty" aria-label="No view access">—</span>
-                }
+
+            <!-- View -->
+            <div class="pm-level-section">
+              <span class="pm-level-header pm-level-header--view">View</span>
+              <div class="pm-chips">
                 @for (s of subjectsByLevel().view; track s) {
-                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                  <div class="pm-chip pm-chip--view">
+                    <button class="pm-chip-label"
+                            [matMenuTriggerFor]="viewMenu"
+                            [attr.aria-label]="'Change level for ' + (subjectLabels()[s] || s)">
+                      <mat-icon class="pm-chip-icon" aria-hidden="true">{{ isGroup(s) ? 'corporate_fare' : 'person' }}</mat-icon>
+                      {{ subjectLabels()[s] || s }}
+                    </button>
+                    <button class="pm-chip-remove"
+                            (click)="confirmRemoveSubject(s)"
+                            [attr.aria-label]="'Remove ' + (subjectLabels()[s] || s)">×</button>
+                    <mat-menu #viewMenu>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'view', 'admin')">Change to Admin</button>
+                      <button mat-menu-item (click)="confirmChangeLevel(s, 'view', 'update')">Change to Update</button>
+                    </mat-menu>
+                  </div>
                 }
-              </span>
+                @if (subjectsByLevel().view.length === 0) {
+                  <span class="pm-chips-empty" aria-label="No view access">—</span>
+                }
+              </div>
             </div>
+
           </div>
-          <mat-divider></mat-divider>
 
-          <!-- Add access button — above the edit rows -->
-          @if (!showAddPanel()) {
-            <button mat-stroked-button class="pm-add-access-btn"
-                    (click)="openAddPerson()"
-                    aria-label="Add access for a person or group">
-              <mat-icon aria-hidden="true">person_add</mat-icon>
-              Add access
-            </button>
-          }
+          <!-- Add access -->
+          <div class="pm-add-section">
+            @if (!showAddPanel()) {
+              <button mat-stroked-button class="pm-add-access-btn"
+                      (click)="openAddPerson()"
+                      aria-label="Add access for a person or group">
+                <mat-icon aria-hidden="true">person_add</mat-icon>
+                Add access
+              </button>
+            }
 
-          <!-- Subject list with computed levels -->
-          @if (uniqueSubjects().length === 0) {
-            <p class="pm-empty-state">No one has access to this record yet.</p>
-          }
-          @for (subject of uniqueSubjects(); track subject) {
-            <div class="pm-subject-row">
-              <mat-icon class="pm-subject-type-icon" aria-hidden="true">{{ isGroup(subject) ? 'corporate_fare' : 'person' }}</mat-icon>
-              <span class="pm-subject-name">{{ subjectLabels()[subject] || subject }}</span>
-              @if (subjectLevel(subject) !== null) {
-                <mat-form-field appearance="outline" class="pm-level-select-field" subscriptSizing="dynamic">
-                  <mat-select [value]="subjectLevel(subject)"
-                              (selectionChange)="confirmSetLevel(subject, $event.value)"
-                              [attr.aria-label]="'Access level for ' + (subjectLabels()[subject] || subject)">
-                    <mat-option value="view">View</mat-option>
-                    <mat-option value="update">Update</mat-option>
-                    <mat-option value="admin">Admin</mat-option>
+            @if (showAddPanel()) {
+              <div class="pm-add-person-panel" role="region" aria-label="Grant access to a person or group">
+
+                @if (staged().length > 0) {
+                  <mat-chip-set class="pm-staged-chips" aria-label="People to be granted access">
+                    @for (p of staged(); track p.id) {
+                      <mat-chip (removed)="unstage(p.id)" [attr.aria-label]="p.label">
+                        {{ p.label }}
+                        <button matChipRemove [attr.aria-label]="'Remove ' + p.label">
+                          <mat-icon>cancel</mat-icon>
+                        </button>
+                      </mat-chip>
+                    }
+                  </mat-chip-set>
+                }
+
+                <mat-form-field appearance="outline" class="pm-people-field">
+                  <mat-label>Search NIST personnel</mat-label>
+                  <input matInput
+                         [(ngModel)]="peopleQuery"
+                         (input)="onPeopleQueryChange(peopleQuery)"
+                         [matAutocomplete]="personAuto"
+                         placeholder="Type a name…"
+                         aria-label="Search for a person to add" />
+                  @if (peopleSearchLoading()) {
+                    <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
+                  }
+                </mat-form-field>
+                <mat-autocomplete #personAuto (optionSelected)="stagePerson($event.option.value)">
+                  @for (suggestion of peopleSuggestions(); track suggestion) {
+                    <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
+                  }
+                </mat-autocomplete>
+
+                <mat-form-field appearance="outline" class="pm-group-field">
+                  <mat-label>Search groups or orgs</mat-label>
+                  <input matInput
+                         [(ngModel)]="groupQuery"
+                         (input)="onGroupQueryChange(groupQuery)"
+                         [matAutocomplete]="groupAuto"
+                         placeholder="My groups or NIST orgs…"
+                         aria-label="Search for a group to add" />
+                </mat-form-field>
+                <mat-autocomplete #groupAuto [displayWith]="displayGroupLabel"
+                                  (optionSelected)="stageGroupSuggestion($event.option.value)">
+                  @for (s of groupSuggestions(); track s.id) {
+                    <mat-option [value]="s">
+                      <mat-icon>{{ s.type === 'midas' ? 'group' : 'corporate_fare' }}</mat-icon>
+                      {{ s.name }}
+                    </mat-option>
+                  }
+                </mat-autocomplete>
+
+                @if (nistOrgsLoading()) {
+                  <div class="pm-loading pm-loading--small" aria-live="polite">
+                    <mat-progress-spinner mode="indeterminate" diameter="14" color="primary"></mat-progress-spinner>
+                    <span>Loading your org units…</span>
+                  </div>
+                } @else if (nistOrgs().length > 0) {
+                  <div class="pm-org-units">
+                    <span class="pm-group-options-label">Your org units:</span>
+                    <div class="pm-group-option-btns">
+                      @for (org of nistOrgs(); track org.id) {
+                        <button mat-stroked-button
+                                class="pm-group-option-btn"
+                                [class.pm-group-option-btn--staged]="isNistOrgStaged(org.id)"
+                                [attr.aria-label]="'Add org unit ' + org.name"
+                                [attr.aria-pressed]="isNistOrgStaged(org.id)"
+                                (click)="stageNistOrg(org)">
+                          <mat-icon>corporate_fare</mat-icon>
+                          {{ org.name }}
+                        </button>
+                      }
+                    </div>
+                  </div>
+                }
+
+                <mat-form-field appearance="outline" class="pm-level-field">
+                  <mat-label>Access level</mat-label>
+                  <mat-select [(ngModel)]="grantLevelValue" aria-label="Select access level to grant">
+                    <mat-option value="view">View — read only</mat-option>
+                    <mat-option value="update">Update — read + write</mat-option>
+                    <mat-option value="admin">Admin — full access</mat-option>
                   </mat-select>
                 </mat-form-field>
-              } @else {
-                <span class="pm-level-badge pm-level-badge--custom" aria-label="Custom permission (set outside this tool)">custom</span>
-              }
-              <button mat-icon-button class="pm-remove-btn"
-                      [attr.aria-label]="'Remove access for ' + (subjectLabels()[subject] || subject)"
-                      (click)="confirmRemoveSubject(subject)">
-                <mat-icon>person_remove</mat-icon>
-              </button>
-            </div>
-          }
 
-          @if (showAddPanel()) {
-            <div class="pm-add-person-panel" role="region" aria-label="Grant access to a person or group">
-
-              @if (staged().length > 0) {
-                <mat-chip-set class="pm-staged-chips" aria-label="People to be granted access">
-                  @for (p of staged(); track p.id) {
-                    <mat-chip (removed)="unstage(p.id)" [attr.aria-label]="p.label">
-                      {{ p.label }}
-                      <button matChipRemove [attr.aria-label]="'Remove ' + p.label">
-                        <mat-icon>cancel</mat-icon>
-                      </button>
-                    </mat-chip>
-                  }
-                </mat-chip-set>
-              }
-
-              <mat-form-field appearance="outline" class="pm-people-field">
-                <mat-label>Search NIST personnel</mat-label>
-                <input matInput
-                       [(ngModel)]="peopleQuery"
-                       (input)="onPeopleQueryChange(peopleQuery)"
-                       [matAutocomplete]="personAuto"
-                       placeholder="Type a name…"
-                       aria-label="Search for a person to add" />
-                @if (peopleSearchLoading()) {
-                  <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
-                }
-              </mat-form-field>
-              <mat-autocomplete #personAuto (optionSelected)="stagePerson($event.option.value)">
-                @for (suggestion of peopleSuggestions(); track suggestion) {
-                  <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
-                }
-              </mat-autocomplete>
-
-              <mat-form-field appearance="outline" class="pm-group-field">
-                <mat-label>Search groups or orgs</mat-label>
-                <input matInput
-                       [(ngModel)]="groupQuery"
-                       (input)="onGroupQueryChange(groupQuery)"
-                       [matAutocomplete]="groupAuto"
-                       placeholder="My groups or NIST orgs…"
-                       aria-label="Search for a group to add" />
-              </mat-form-field>
-              <mat-autocomplete #groupAuto [displayWith]="displayGroupLabel"
-                                (optionSelected)="stageGroupSuggestion($event.option.value)">
-                @for (s of groupSuggestions(); track s.id) {
-                  <mat-option [value]="s">
-                    <mat-icon>{{ s.type === 'midas' ? 'group' : 'corporate_fare' }}</mat-icon>
-                    {{ s.name }}
-                  </mat-option>
-                }
-              </mat-autocomplete>
-
-              @if (nistOrgsLoading()) {
-                <div class="pm-loading pm-loading--small" aria-live="polite">
-                  <mat-progress-spinner mode="indeterminate" diameter="14" color="primary"></mat-progress-spinner>
-                  <span>Loading your org units…</span>
+                <div class="pm-add-person-actions">
+                  <button mat-flat-button color="primary"
+                          [disabled]="staged().length === 0"
+                          (click)="confirmGrantLevel(grantLevelValue)"
+                          [attr.aria-label]="'Grant ' + grantLevelValue + ' access to selected people'">
+                    Grant {{ grantLevelValue }}
+                  </button>
+                  <button mat-button (click)="closeAddPerson()">Cancel</button>
                 </div>
-              } @else if (nistOrgs().length > 0) {
-                <div class="pm-org-units">
-                  <span class="pm-group-options-label">Your org units:</span>
-                  <div class="pm-group-option-btns">
-                    @for (org of nistOrgs(); track org.id) {
-                      <button mat-stroked-button
-                              class="pm-group-option-btn"
-                              [class.pm-group-option-btn--staged]="isNistOrgStaged(org.id)"
-                              [attr.aria-label]="'Add org unit ' + org.name"
-                              [attr.aria-pressed]="isNistOrgStaged(org.id)"
-                              (click)="stageNistOrg(org)">
-                        <mat-icon>corporate_fare</mat-icon>
-                        {{ org.name }}
-                      </button>
-                    }
-                  </div>
-                </div>
-              }
 
-              <mat-form-field appearance="outline" class="pm-level-field">
-                <mat-label>Access level</mat-label>
-                <mat-select [(ngModel)]="grantLevelValue" aria-label="Select access level to grant">
-                  <mat-option value="view">View — read only</mat-option>
-                  <mat-option value="update">Update — read + write</mat-option>
-                  <mat-option value="admin">Admin — full access</mat-option>
-                </mat-select>
-              </mat-form-field>
-
-              <div class="pm-add-person-actions">
-                <button mat-flat-button color="primary"
-                        [disabled]="staged().length === 0"
-                        (click)="confirmGrantLevel(grantLevelValue)"
-                        [attr.aria-label]="'Grant ' + grantLevelValue + ' access to selected people'">
-                  Grant {{ grantLevelValue }}
-                </button>
-                <button mat-button (click)="closeAddPerson()">Cancel</button>
               </div>
+            }
+          </div>
 
-            </div>
-          }
         }
       </section>
     }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -12,15 +12,124 @@
   </mat-card-header>
 
   <mat-card-content>
-    @for (perm of perms; track perm) {
-      <div class="pm-perm-row">
-        <span class="pm-perm-label">{{ perm }}</span>
-        <div class="pm-perm-chips" aria-hidden="true">
-          <div class="pm-chip-ghost"></div>
-          <div class="pm-chip-ghost pm-chip-ghost--short"></div>
+
+    <!-- Permissions section -->
+    <section class="pm-section" aria-label="Permission levels">
+      @for (perm of perms; track perm) {
+        <div class="pm-perm-row">
+          <span class="pm-perm-label">{{ perm }}</span>
+          <div class="pm-perm-chips" aria-hidden="true">
+            <div class="pm-chip-ghost"></div>
+            <div class="pm-chip-ghost pm-chip-ghost--short"></div>
+          </div>
+          <div class="pm-add-ghost" aria-hidden="true"></div>
         </div>
-        <div class="pm-add-ghost" aria-hidden="true"></div>
+      }
+    </section>
+
+    <mat-divider></mat-divider>
+
+    <!-- My Groups section -->
+    <section class="pm-section pm-groups" aria-label="My groups">
+
+      <div class="pm-groups-header">
+        <h3 class="pm-section-title">My Groups</h3>
+        <button
+          mat-stroked-button
+          class="pm-new-group-btn"
+          (click)="showNewGroupForm.set(true)"
+          [disabled]="showNewGroupForm()"
+          aria-label="Create a new group">
+          <mat-icon>add</mat-icon>
+          New Group
+        </button>
       </div>
-    }
+
+      <!-- Create group form -->
+      @if (showNewGroupForm()) {
+        <div class="pm-new-group-form">
+          <mat-form-field appearance="outline" class="pm-group-name-field">
+            <mat-label>Group name</mat-label>
+            <input
+              matInput
+              [(ngModel)]="newGroupName"
+              (keydown.enter)="createGroup()"
+              (keydown.escape)="cancelCreate()"
+              placeholder="e.g. lab-team"
+              aria-label="New group name"
+              autofocus />
+          </mat-form-field>
+          <div class="pm-form-actions">
+            <button mat-flat-button color="primary" (click)="createGroup()" [disabled]="!newGroupName.trim()">
+              Create
+            </button>
+            <button mat-button (click)="cancelCreate()">Cancel</button>
+          </div>
+        </div>
+      }
+
+      <!-- Group list -->
+      @if (groups().length === 0 && !showNewGroupForm()) {
+        <p class="pm-empty-state">No groups yet. Create one to share access easily.</p>
+      }
+
+      @for (group of groups(); track group.id) {
+        <div class="pm-group-item">
+
+          <div class="pm-group-row">
+            <span class="pm-group-name">{{ group.name }}</span>
+            <span class="pm-member-count" [attr.aria-label]="group.members.length + ' members'">
+              {{ group.members.length }} member{{ group.members.length !== 1 ? 's' : '' }}
+            </span>
+            <div class="pm-group-actions">
+              <button
+                mat-icon-button
+                [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
+                [attr.aria-expanded]="expandedGroupId() === group.id"
+                (click)="toggleGroup(group.id)">
+                <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
+              </button>
+              <button
+                mat-icon-button
+                class="pm-delete-btn"
+                [attr.aria-label]="'Delete group ' + group.name"
+                (click)="deleteGroup(group.id)">
+                <mat-icon>delete_outline</mat-icon>
+              </button>
+            </div>
+          </div>
+
+          <!-- Members panel -->
+          @if (expandedGroupId() === group.id) {
+            <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
+              @if (group.members.length === 0) {
+                <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
+              }
+              @for (member of group.members; track member) {
+                <div class="pm-member-row">
+                  <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
+                  <span class="pm-member-name">{{ member }}</span>
+                  <button
+                    mat-icon-button
+                    class="pm-member-remove"
+                    [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
+                    (click)="removeGroupMember(group.id, member)">
+                    <mat-icon>close</mat-icon>
+                  </button>
+                </div>
+              }
+              <!-- Add member placeholder -->
+              <div class="pm-add-member-ghost" aria-hidden="true">
+                <mat-icon>person_add</mat-icon>
+                <span>Add member…</span>
+              </div>
+            </div>
+          }
+
+        </div>
+      }
+
+    </section>
+
   </mat-card-content>
 </mat-card>

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -85,6 +85,9 @@
                 <mat-option [value]="s">
                   <mat-icon>{{ s.type === 'midas' ? 'group' : 'corporate_fare' }}</mat-icon>
                   {{ s.name }}
+                  @if (s.type !== 'midas') {
+                    <span class="pm-org-type-badge">{{ orgTypeLabel(s.type) }}</span>
+                  }
                 </mat-option>
               }
             </mat-autocomplete>
@@ -289,11 +292,12 @@
                         <button mat-stroked-button
                                 class="pm-group-option-btn"
                                 [class.pm-group-option-btn--staged]="isNistOrgStaged(org.id)"
-                                [attr.aria-label]="'Add org unit ' + org.name"
+                                [attr.aria-label]="'Add ' + orgTypeLabel(org.type) + ' ' + org.name"
                                 [attr.aria-pressed]="isNistOrgStaged(org.id)"
                                 (click)="stageNistOrg(org)">
                           <mat-icon>corporate_fare</mat-icon>
                           {{ org.name }}
+                          <span class="pm-org-type-badge">{{ orgTypeLabel(org.type) }}</span>
                         </button>
                       }
                     </div>
@@ -390,10 +394,10 @@
                 <div class="pm-group-actions">
                   <button
                     mat-icon-button
-                    [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
+                    [attr.aria-label]="(expandedGroupId() === group.id ? 'Close add member' : 'Add member to') + ' group ' + group.name"
                     [attr.aria-expanded]="expandedGroupId() === group.id"
                     (click)="toggleGroup(group.id)">
-                    <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
+                    <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'person_add' }}</mat-icon>
                   </button>
                   <button
                     mat-icon-button
@@ -405,43 +409,44 @@
                 </div>
               </div>
 
-              @if (expandedGroupId() === group.id) {
-                <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
-                  @if (group.members.length === 0) {
-                    <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
-                  }
-                  @for (member of group.members; track member) {
-                    <div class="pm-member-row">
-                      <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
-                      <span class="pm-member-name">{{ member }}</span>
-                      <button
-                        mat-icon-button
-                        class="pm-member-remove"
-                        [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
-                        (click)="removeGroupMember(group.id, member)">
-                        <mat-icon>close</mat-icon>
-                      </button>
-                    </div>
-                  }
-                  <div class="pm-add-member-form">
-                    <mat-form-field appearance="outline" class="pm-add-member-field">
-                      <mat-label>Add member</mat-label>
-                      <input matInput
-                             [(ngModel)]="memberQuery"
-                             (input)="onMemberQueryChange(memberQuery)"
-                             [matAutocomplete]="memberAuto"
-                             placeholder="Type a name…"
-                             aria-label="Search for a person to add to this group" />
-                      @if (memberSearchLoading()) {
-                        <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
-                      }
-                    </mat-form-field>
-                    <mat-autocomplete #memberAuto (optionSelected)="addGroupMember(group.id, $event.option.value)">
-                      @for (s of memberSuggestions(); track s) {
-                        <mat-option [value]="s">{{ s }}</mat-option>
-                      }
-                    </mat-autocomplete>
+              <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
+                @if (group.members.length === 0) {
+                  <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
+                }
+                @for (member of group.members; track member) {
+                  <div class="pm-member-row">
+                    <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
+                    <span class="pm-member-name">{{ subjectLabels()[member] || member }}</span>
+                    <button
+                      mat-icon-button
+                      class="pm-member-remove"
+                      [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
+                      (click)="removeGroupMember(group.id, member)">
+                      <mat-icon>close</mat-icon>
+                    </button>
                   </div>
+                }
+              </div>
+
+              @if (expandedGroupId() === group.id) {
+                <div class="pm-add-member-form">
+                  <mat-form-field appearance="outline" class="pm-add-member-field">
+                    <mat-label>Add member</mat-label>
+                    <input matInput
+                           [(ngModel)]="memberQuery"
+                           (input)="onMemberQueryChange(memberQuery)"
+                           [matAutocomplete]="memberAuto"
+                           placeholder="Type a name…"
+                           aria-label="Search for a person to add to this group" />
+                    @if (memberSearchLoading()) {
+                      <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
+                    }
+                  </mat-form-field>
+                  <mat-autocomplete #memberAuto (optionSelected)="addGroupMember(group.id, $event.option.value)">
+                    @for (s of memberSuggestions(); track s) {
+                      <mat-option [value]="s">{{ s }}</mat-option>
+                    }
+                  </mat-autocomplete>
                 </div>
               }
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -1,6 +1,6 @@
 <mat-card class="pm-card">
   <mat-card-header>
-    <mat-card-title>Access Control</mat-card-title>
+    <mat-card-title>{{ section === 'groups' ? 'My Groups' : 'Access Control' }}</mat-card-title>
     @if (records.length === 1) {
       <mat-card-subtitle>{{ records[0].id }}</mat-card-subtitle>
     } @else if (records.length > 1) {
@@ -10,157 +10,384 @@
 
   <mat-card-content>
 
-    <!-- Permissions section -->
-    <section class="pm-section" aria-label="Permission levels">
+    <!-- ── Permissions section ─────────────────────────────────────────── -->
+    @if (section === 'permissions') {
+      <section class="pm-section" aria-label="Permission levels">
 
-      @if (aclsLoading()) {
-        <div class="pm-loading" aria-live="polite" aria-label="Loading permissions">
-          <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
-          <span>Loading permissions…</span>
-        </div>
-      } @else if (aclsError()) {
-        <p class="pm-error" role="alert">{{ aclsError() }}</p>
-      } @else if (records.length > 1) {
-        <p class="pm-multi-hint">Select a single record to view and edit its permissions.</p>
-      } @else if (!acls()) {
-        <p class="pm-empty-state">Select a record to load its permissions.</p>
-      } @else {
-        @for (perm of perms; track perm) {
-          <div class="pm-perm-row">
-            <span class="pm-perm-label">{{ perm }}</span>
-            <div class="pm-perm-chips" role="list" [attr.aria-label]="perm + ' permissions'">
-              @for (subject of subjectsFor(perm); track subject) {
-                <mat-chip-row
-                  role="listitem"
-                  (removed)="revokePermission(perm, subject)"
-                  [attr.aria-label]="'Remove ' + subject + ' from ' + perm">
-                  {{ subject }}
-                  <button matChipRemove [attr.aria-label]="'Revoke ' + perm + ' for ' + subject"
-                          (click)="revokePermission(perm, subject)">
-                    <mat-icon>cancel</mat-icon>
-                  </button>
-                </mat-chip-row>
-              }
-              @if (subjectsFor(perm).length === 0) {
-                <span class="pm-perm-empty" [attr.aria-label]="'No subjects with ' + perm + ' access'">—</span>
-              }
-            </div>
-            <div class="pm-add-ghost" aria-hidden="true"></div>
+        @if (aclsLoading()) {
+          <div class="pm-loading" aria-live="polite" aria-label="Loading permissions">
+            <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
+            <span>Loading permissions…</span>
           </div>
-        }
-      }
-    </section>
+        } @else if (aclsError()) {
+          <p class="pm-error" role="alert">{{ aclsError() }}</p>
+        } @else if (records.length > 1) {
 
-    <mat-divider></mat-divider>
+          <!-- Bulk grant panel -->
+          <div class="pm-bulk-panel">
+            <p class="pm-bulk-hint">
+              <mat-icon aria-hidden="true">group_work</mat-icon>
+              Grant access to all <strong>{{ records.length }}</strong> selected records.
+            </p>
 
-    <!-- My Groups section -->
-    <section class="pm-section pm-groups" aria-label="My groups">
-
-      <div class="pm-groups-header">
-        <h3 class="pm-section-title">My Groups</h3>
-        <button
-          mat-stroked-button
-          class="pm-new-group-btn"
-          (click)="showNewGroupForm.set(true)"
-          [disabled]="showNewGroupForm()"
-          aria-label="Create a new group">
-          <mat-icon>add</mat-icon>
-          New Group
-        </button>
-      </div>
-
-      @if (groupsLoading()) {
-        <div class="pm-loading" aria-live="polite" aria-label="Loading groups">
-          <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
-          <span>Loading groups…</span>
-        </div>
-      } @else if (groupsError()) {
-        <p class="pm-error" role="alert">{{ groupsError() }}</p>
-      } @else {
-
-        <!-- Create group form -->
-        @if (showNewGroupForm()) {
-          <div class="pm-new-group-form">
-            <mat-form-field appearance="outline" class="pm-group-name-field">
-              <mat-label>Group name</mat-label>
-              <input
-                matInput
-                [(ngModel)]="newGroupName"
-                (keydown.enter)="createGroup()"
-                (keydown.escape)="cancelCreate()"
-                placeholder="e.g. lab-team"
-                aria-label="New group name"
-                autofocus />
+            <mat-form-field appearance="outline" class="pm-perm-select-field">
+              <mat-label>Access level</mat-label>
+              <mat-select [(ngModel)]="bulkLevel" aria-label="Select access level to grant">
+                <mat-option value="view">View — read only</mat-option>
+                <mat-option value="update">Update — read + write</mat-option>
+                <mat-option value="admin">Admin — full access</mat-option>
+              </mat-select>
             </mat-form-field>
-            <div class="pm-form-actions">
-              <button mat-flat-button color="primary" (click)="createGroup()" [disabled]="!newGroupName.trim()">
-                Create
-              </button>
-              <button mat-button (click)="cancelCreate()">Cancel</button>
-            </div>
-          </div>
-        }
 
-        @if (groups().length === 0 && !showNewGroupForm()) {
-          <p class="pm-empty-state">No groups yet. Create one to share access easily.</p>
-        }
-
-        @for (group of groups(); track group.id) {
-          <div class="pm-group-item">
-
-            <div class="pm-group-row">
-              <span class="pm-group-name">{{ group.name }}</span>
-              <span class="pm-member-count" [attr.aria-label]="group.members.length + ' members'">
-                {{ group.members.length }} member{{ group.members.length !== 1 ? 's' : '' }}
-              </span>
-              <div class="pm-group-actions">
-                <button
-                  mat-icon-button
-                  [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
-                  [attr.aria-expanded]="expandedGroupId() === group.id"
-                  (click)="toggleGroup(group.id)">
-                  <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
-                </button>
-                <button
-                  mat-icon-button
-                  class="pm-delete-btn"
-                  [attr.aria-label]="'Delete group ' + group.name"
-                  (click)="deleteGroup(group.id)">
-                  <mat-icon>delete_outline</mat-icon>
-                </button>
-              </div>
-            </div>
-
-            @if (expandedGroupId() === group.id) {
-              <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
-                @if (group.members.length === 0) {
-                  <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
-                }
-                @for (member of group.members; track member) {
-                  <div class="pm-member-row">
-                    <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
-                    <span class="pm-member-name">{{ member }}</span>
-                    <button
-                      mat-icon-button
-                      class="pm-member-remove"
-                      [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
-                      (click)="removeGroupMember(group.id, member)">
-                      <mat-icon>close</mat-icon>
+            @if (staged().length > 0) {
+              <mat-chip-set class="pm-staged-chips" aria-label="People and groups to be granted access">
+                @for (p of staged(); track p.id) {
+                  <mat-chip (removed)="unstage(p.id)" [attr.aria-label]="p.label">
+                    {{ p.label }}
+                    <button matChipRemove [attr.aria-label]="'Remove ' + p.label">
+                      <mat-icon>cancel</mat-icon>
                     </button>
-                  </div>
+                  </mat-chip>
                 }
-                <div class="pm-add-member-ghost" aria-hidden="true">
-                  <mat-icon>person_add</mat-icon>
-                  <span>Add member…</span>
+              </mat-chip-set>
+            }
+
+            <mat-form-field appearance="outline" class="pm-people-field">
+              <mat-label>Search NIST personnel</mat-label>
+              <input matInput
+                     [(ngModel)]="peopleQuery"
+                     (input)="onPeopleQueryChange(peopleQuery)"
+                     [matAutocomplete]="bulkPersonAuto"
+                     placeholder="Type a name…"
+                     aria-label="Search for a person to add" />
+              @if (peopleSearchLoading()) {
+                <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
+              }
+            </mat-form-field>
+            <mat-autocomplete #bulkPersonAuto (optionSelected)="stagePerson($event.option.value)">
+              @for (suggestion of peopleSuggestions(); track suggestion) {
+                <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
+              }
+            </mat-autocomplete>
+
+            <mat-form-field appearance="outline" class="pm-group-field">
+              <mat-label>Search groups or orgs</mat-label>
+              <input matInput
+                     [(ngModel)]="groupQuery"
+                     (input)="onGroupQueryChange(groupQuery)"
+                     [matAutocomplete]="bulkGroupAuto"
+                     placeholder="My groups or NIST orgs…"
+                     aria-label="Search for a group to add" />
+            </mat-form-field>
+            <mat-autocomplete #bulkGroupAuto [displayWith]="displayGroupLabel"
+                              (optionSelected)="stageGroupSuggestion($event.option.value)">
+              @for (s of groupSuggestions(); track s.id) {
+                <mat-option [value]="s">
+                  <mat-icon>{{ s.type === 'midas' ? 'group' : 'corporate_fare' }}</mat-icon>
+                  {{ s.name }}
+                </mat-option>
+              }
+            </mat-autocomplete>
+
+            @if (nistOrgs().length > 0) {
+              <div class="pm-org-units">
+                <span class="pm-group-options-label">Your org units:</span>
+                <div class="pm-group-option-btns">
+                  @for (org of nistOrgs(); track org.id) {
+                    <button mat-stroked-button
+                            class="pm-group-option-btn"
+                            [class.pm-group-option-btn--staged]="isNistOrgStaged(org.id)"
+                            [attr.aria-label]="'Add org unit ' + org.name"
+                            [attr.aria-pressed]="isNistOrgStaged(org.id)"
+                            (click)="stageNistOrg(org)">
+                      <mat-icon>corporate_fare</mat-icon>
+                      {{ org.name }}
+                    </button>
+                  }
                 </div>
               </div>
             }
 
+            @if (bulkGrantError()) {
+              <p class="pm-error" role="alert">{{ bulkGrantError() }}</p>
+            }
+            <div class="pm-add-person-actions">
+              <button mat-flat-button color="primary"
+                      [disabled]="staged().length === 0 || bulkGranting()"
+                      (click)="confirmBulkGrant()"
+                      [attr.aria-label]="'Grant ' + bulkLevel + ' to all ' + records.length + ' records'">
+                @if (bulkGranting()) { Granting… }
+                @else { Grant {{ bulkLevel }} to all {{ records.length }} records }
+              </button>
+            </div>
           </div>
-        }
-      }
 
-    </section>
+        } @else if (!acls()) {
+          <p class="pm-empty-state">Select a record to load its permissions.</p>
+        } @else {
+          <!-- Subject list with computed levels -->
+          @if (uniqueSubjects().length === 0) {
+            <p class="pm-empty-state">No one has access to this record yet.</p>
+          }
+          @for (subject of uniqueSubjects(); track subject) {
+            <div class="pm-subject-row">
+              <span class="pm-subject-name">{{ subjectLabels()[subject] || subject }}</span>
+              @if (subjectLevel(subject) !== null) {
+                <mat-form-field appearance="outline" class="pm-level-select-field" subscriptSizing="dynamic">
+                  <mat-select [value]="subjectLevel(subject)"
+                              (selectionChange)="confirmSetLevel(subject, $event.value)"
+                              [attr.aria-label]="'Access level for ' + (subjectLabels()[subject] || subject)">
+                    <mat-option value="view">View</mat-option>
+                    <mat-option value="update">Update</mat-option>
+                    <mat-option value="admin">Admin</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              } @else {
+                <span class="pm-level-badge pm-level-badge--custom" aria-label="Custom permission (set outside this tool)">custom</span>
+              }
+              <button mat-icon-button class="pm-remove-btn"
+                      [attr.aria-label]="'Remove access for ' + (subjectLabels()[subject] || subject)"
+                      (click)="confirmRemoveSubject(subject)">
+                <mat-icon>person_remove</mat-icon>
+              </button>
+            </div>
+          }
+
+          @if (!showAddPanel()) {
+            <button mat-stroked-button class="pm-add-access-btn"
+                    (click)="openAddPerson()"
+                    aria-label="Add access for a person or group">
+              <mat-icon aria-hidden="true">person_add</mat-icon>
+              Add access
+            </button>
+          }
+
+          @if (showAddPanel()) {
+            <div class="pm-add-person-panel" role="region" aria-label="Grant access to a person or group">
+
+              @if (staged().length > 0) {
+                <mat-chip-set class="pm-staged-chips" aria-label="People to be granted access">
+                  @for (p of staged(); track p.id) {
+                    <mat-chip (removed)="unstage(p.id)" [attr.aria-label]="p.label">
+                      {{ p.label }}
+                      <button matChipRemove [attr.aria-label]="'Remove ' + p.label">
+                        <mat-icon>cancel</mat-icon>
+                      </button>
+                    </mat-chip>
+                  }
+                </mat-chip-set>
+              }
+
+              <mat-form-field appearance="outline" class="pm-people-field">
+                <mat-label>Search NIST personnel</mat-label>
+                <input matInput
+                       [(ngModel)]="peopleQuery"
+                       (input)="onPeopleQueryChange(peopleQuery)"
+                       [matAutocomplete]="personAuto"
+                       placeholder="Type a name…"
+                       aria-label="Search for a person to add" />
+                @if (peopleSearchLoading()) {
+                  <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
+                }
+              </mat-form-field>
+              <mat-autocomplete #personAuto (optionSelected)="stagePerson($event.option.value)">
+                @for (suggestion of peopleSuggestions(); track suggestion) {
+                  <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
+                }
+              </mat-autocomplete>
+
+              <mat-form-field appearance="outline" class="pm-group-field">
+                <mat-label>Search groups or orgs</mat-label>
+                <input matInput
+                       [(ngModel)]="groupQuery"
+                       (input)="onGroupQueryChange(groupQuery)"
+                       [matAutocomplete]="groupAuto"
+                       placeholder="My groups or NIST orgs…"
+                       aria-label="Search for a group to add" />
+              </mat-form-field>
+              <mat-autocomplete #groupAuto [displayWith]="displayGroupLabel"
+                                (optionSelected)="stageGroupSuggestion($event.option.value)">
+                @for (s of groupSuggestions(); track s.id) {
+                  <mat-option [value]="s">
+                    <mat-icon>{{ s.type === 'midas' ? 'group' : 'corporate_fare' }}</mat-icon>
+                    {{ s.name }}
+                  </mat-option>
+                }
+              </mat-autocomplete>
+
+              @if (nistOrgsLoading()) {
+                <div class="pm-loading pm-loading--small" aria-live="polite">
+                  <mat-progress-spinner mode="indeterminate" diameter="14" color="primary"></mat-progress-spinner>
+                  <span>Loading your org units…</span>
+                </div>
+              } @else if (nistOrgs().length > 0) {
+                <div class="pm-org-units">
+                  <span class="pm-group-options-label">Your org units:</span>
+                  <div class="pm-group-option-btns">
+                    @for (org of nistOrgs(); track org.id) {
+                      <button mat-stroked-button
+                              class="pm-group-option-btn"
+                              [class.pm-group-option-btn--staged]="isNistOrgStaged(org.id)"
+                              [attr.aria-label]="'Add org unit ' + org.name"
+                              [attr.aria-pressed]="isNistOrgStaged(org.id)"
+                              (click)="stageNistOrg(org)">
+                        <mat-icon>corporate_fare</mat-icon>
+                        {{ org.name }}
+                      </button>
+                    }
+                  </div>
+                </div>
+              }
+
+              <mat-form-field appearance="outline" class="pm-level-field">
+                <mat-label>Access level</mat-label>
+                <mat-select [(ngModel)]="grantLevelValue" aria-label="Select access level to grant">
+                  <mat-option value="view">View — read only</mat-option>
+                  <mat-option value="update">Update — read + write</mat-option>
+                  <mat-option value="admin">Admin — full access</mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              <div class="pm-add-person-actions">
+                <button mat-flat-button color="primary"
+                        [disabled]="staged().length === 0"
+                        (click)="confirmGrantLevel(grantLevelValue)"
+                        [attr.aria-label]="'Grant ' + grantLevelValue + ' access to selected people'">
+                  Grant {{ grantLevelValue }}
+                </button>
+                <button mat-button (click)="closeAddPerson()">Cancel</button>
+              </div>
+
+            </div>
+          }
+        }
+      </section>
+    }
+
+    <!-- ── My Groups section ───────────────────────────────────────────── -->
+    @if (section === 'groups') {
+      <section class="pm-section pm-groups" aria-label="My groups">
+
+        <div class="pm-groups-header">
+          <h3 class="pm-section-title">My Groups</h3>
+          <button
+            mat-stroked-button
+            class="pm-new-group-btn"
+            (click)="showNewGroupForm.set(true)"
+            [disabled]="showNewGroupForm()"
+            aria-label="Create a new group">
+            <mat-icon>add</mat-icon>
+            New Group
+          </button>
+        </div>
+
+        @if (groupsLoading()) {
+          <div class="pm-loading" aria-live="polite" aria-label="Loading groups">
+            <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
+            <span>Loading groups…</span>
+          </div>
+        } @else if (groupsError()) {
+          <p class="pm-error" role="alert">{{ groupsError() }}</p>
+        } @else {
+
+          @if (showNewGroupForm()) {
+            <div class="pm-new-group-form">
+              <mat-form-field appearance="outline" class="pm-group-name-field">
+                <mat-label>Group name</mat-label>
+                <input
+                  matInput
+                  [(ngModel)]="newGroupName"
+                  (keydown.enter)="createGroup()"
+                  (keydown.escape)="cancelCreate()"
+                  placeholder="e.g. lab-team"
+                  aria-label="New group name"
+                  autofocus />
+              </mat-form-field>
+              <div class="pm-form-actions">
+                <button mat-flat-button color="primary" (click)="createGroup()" [disabled]="!newGroupName.trim()">
+                  Create
+                </button>
+                <button mat-button (click)="cancelCreate()">Cancel</button>
+              </div>
+            </div>
+          }
+
+          @if (groups().length === 0 && !showNewGroupForm()) {
+            <p class="pm-empty-state">No groups yet. Create one to share access easily.</p>
+          }
+
+          @for (group of groups(); track group.id) {
+            <div class="pm-group-item">
+
+              <div class="pm-group-row">
+                <span class="pm-group-name">{{ group.name }}</span>
+                <span class="pm-member-count" [attr.aria-label]="group.members.length + ' members'">
+                  {{ group.members.length }} member{{ group.members.length !== 1 ? 's' : '' }}
+                </span>
+                <div class="pm-group-actions">
+                  <button
+                    mat-icon-button
+                    [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
+                    [attr.aria-expanded]="expandedGroupId() === group.id"
+                    (click)="toggleGroup(group.id)">
+                    <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    class="pm-delete-btn"
+                    [attr.aria-label]="'Delete group ' + group.name"
+                    (click)="confirmDeleteGroup(group.id)">
+                    <mat-icon>delete_outline</mat-icon>
+                  </button>
+                </div>
+              </div>
+
+              @if (expandedGroupId() === group.id) {
+                <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
+                  @if (group.members.length === 0) {
+                    <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
+                  }
+                  @for (member of group.members; track member) {
+                    <div class="pm-member-row">
+                      <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
+                      <span class="pm-member-name">{{ member }}</span>
+                      <button
+                        mat-icon-button
+                        class="pm-member-remove"
+                        [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
+                        (click)="removeGroupMember(group.id, member)">
+                        <mat-icon>close</mat-icon>
+                      </button>
+                    </div>
+                  }
+                  <div class="pm-add-member-form">
+                    <mat-form-field appearance="outline" class="pm-add-member-field">
+                      <mat-label>Add member</mat-label>
+                      <input matInput
+                             [(ngModel)]="memberQuery"
+                             (input)="onMemberQueryChange(memberQuery)"
+                             [matAutocomplete]="memberAuto"
+                             placeholder="Type a name…"
+                             aria-label="Search for a person to add to this group" />
+                      @if (memberSearchLoading()) {
+                        <mat-progress-spinner matSuffix mode="indeterminate" diameter="16"></mat-progress-spinner>
+                      }
+                    </mat-form-field>
+                    <mat-autocomplete #memberAuto (optionSelected)="addGroupMember(group.id, $event.option.value)">
+                      @for (s of memberSuggestions(); track s) {
+                        <mat-option [value]="s">{{ s }}</mat-option>
+                      }
+                    </mat-autocomplete>
+                  </div>
+                </div>
+              }
+
+            </div>
+          }
+        }
+
+      </section>
+    }
 
   </mat-card-content>
 </mat-card>

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -4,8 +4,10 @@
       Access Control
       <span class="pm-stub-badge" aria-hidden="true">stub</span>
     </mat-card-title>
-    @if (recordId) {
-      <mat-card-subtitle>{{ recordId }}</mat-card-subtitle>
+    @if (records.length === 1) {
+      <mat-card-subtitle>{{ records[0].id }}</mat-card-subtitle>
+    } @else if (records.length > 1) {
+      <mat-card-subtitle>{{ records.length }} records selected</mat-card-subtitle>
     }
   </mat-card-header>
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -1,0 +1,24 @@
+<mat-card class="pm-card">
+  <mat-card-header>
+    <mat-card-title>
+      Access Control
+      <span class="pm-stub-badge" aria-hidden="true">stub</span>
+    </mat-card-title>
+    @if (recordId) {
+      <mat-card-subtitle>{{ recordId }}</mat-card-subtitle>
+    }
+  </mat-card-header>
+
+  <mat-card-content>
+    @for (perm of perms; track perm) {
+      <div class="pm-perm-row">
+        <span class="pm-perm-label">{{ perm }}</span>
+        <div class="pm-perm-chips" aria-hidden="true">
+          <div class="pm-chip-ghost"></div>
+          <div class="pm-chip-ghost pm-chip-ghost--short"></div>
+        </div>
+        <div class="pm-add-ghost" aria-hidden="true"></div>
+      </div>
+    }
+  </mat-card-content>
+</mat-card>

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -1,9 +1,6 @@
 <mat-card class="pm-card">
   <mat-card-header>
-    <mat-card-title>
-      Access Control
-      <span class="pm-stub-badge" aria-hidden="true">stub</span>
-    </mat-card-title>
+    <mat-card-title>Access Control</mat-card-title>
     @if (records.length === 1) {
       <mat-card-subtitle>{{ records[0].id }}</mat-card-subtitle>
     } @else if (records.length > 1) {
@@ -15,15 +12,42 @@
 
     <!-- Permissions section -->
     <section class="pm-section" aria-label="Permission levels">
-      @for (perm of perms; track perm) {
-        <div class="pm-perm-row">
-          <span class="pm-perm-label">{{ perm }}</span>
-          <div class="pm-perm-chips" aria-hidden="true">
-            <div class="pm-chip-ghost"></div>
-            <div class="pm-chip-ghost pm-chip-ghost--short"></div>
-          </div>
-          <div class="pm-add-ghost" aria-hidden="true"></div>
+
+      @if (aclsLoading()) {
+        <div class="pm-loading" aria-live="polite" aria-label="Loading permissions">
+          <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
+          <span>Loading permissions…</span>
         </div>
+      } @else if (aclsError()) {
+        <p class="pm-error" role="alert">{{ aclsError() }}</p>
+      } @else if (records.length > 1) {
+        <p class="pm-multi-hint">Select a single record to view and edit its permissions.</p>
+      } @else if (!acls()) {
+        <p class="pm-empty-state">Select a record to load its permissions.</p>
+      } @else {
+        @for (perm of perms; track perm) {
+          <div class="pm-perm-row">
+            <span class="pm-perm-label">{{ perm }}</span>
+            <div class="pm-perm-chips" role="list" [attr.aria-label]="perm + ' permissions'">
+              @for (subject of subjectsFor(perm); track subject) {
+                <mat-chip-row
+                  role="listitem"
+                  (removed)="revokePermission(perm, subject)"
+                  [attr.aria-label]="'Remove ' + subject + ' from ' + perm">
+                  {{ subject }}
+                  <button matChipRemove [attr.aria-label]="'Revoke ' + perm + ' for ' + subject"
+                          (click)="revokePermission(perm, subject)">
+                    <mat-icon>cancel</mat-icon>
+                  </button>
+                </mat-chip-row>
+              }
+              @if (subjectsFor(perm).length === 0) {
+                <span class="pm-perm-empty" [attr.aria-label]="'No subjects with ' + perm + ' access'">—</span>
+              }
+            </div>
+            <div class="pm-add-ghost" aria-hidden="true"></div>
+          </div>
+        }
       }
     </section>
 
@@ -45,88 +69,95 @@
         </button>
       </div>
 
-      <!-- Create group form -->
-      @if (showNewGroupForm()) {
-        <div class="pm-new-group-form">
-          <mat-form-field appearance="outline" class="pm-group-name-field">
-            <mat-label>Group name</mat-label>
-            <input
-              matInput
-              [(ngModel)]="newGroupName"
-              (keydown.enter)="createGroup()"
-              (keydown.escape)="cancelCreate()"
-              placeholder="e.g. lab-team"
-              aria-label="New group name"
-              autofocus />
-          </mat-form-field>
-          <div class="pm-form-actions">
-            <button mat-flat-button color="primary" (click)="createGroup()" [disabled]="!newGroupName.trim()">
-              Create
-            </button>
-            <button mat-button (click)="cancelCreate()">Cancel</button>
-          </div>
+      @if (groupsLoading()) {
+        <div class="pm-loading" aria-live="polite" aria-label="Loading groups">
+          <mat-progress-spinner mode="indeterminate" diameter="20" color="primary"></mat-progress-spinner>
+          <span>Loading groups…</span>
         </div>
-      }
+      } @else if (groupsError()) {
+        <p class="pm-error" role="alert">{{ groupsError() }}</p>
+      } @else {
 
-      <!-- Group list -->
-      @if (groups().length === 0 && !showNewGroupForm()) {
-        <p class="pm-empty-state">No groups yet. Create one to share access easily.</p>
-      }
-
-      @for (group of groups(); track group.id) {
-        <div class="pm-group-item">
-
-          <div class="pm-group-row">
-            <span class="pm-group-name">{{ group.name }}</span>
-            <span class="pm-member-count" [attr.aria-label]="group.members.length + ' members'">
-              {{ group.members.length }} member{{ group.members.length !== 1 ? 's' : '' }}
-            </span>
-            <div class="pm-group-actions">
-              <button
-                mat-icon-button
-                [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
-                [attr.aria-expanded]="expandedGroupId() === group.id"
-                (click)="toggleGroup(group.id)">
-                <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
+        <!-- Create group form -->
+        @if (showNewGroupForm()) {
+          <div class="pm-new-group-form">
+            <mat-form-field appearance="outline" class="pm-group-name-field">
+              <mat-label>Group name</mat-label>
+              <input
+                matInput
+                [(ngModel)]="newGroupName"
+                (keydown.enter)="createGroup()"
+                (keydown.escape)="cancelCreate()"
+                placeholder="e.g. lab-team"
+                aria-label="New group name"
+                autofocus />
+            </mat-form-field>
+            <div class="pm-form-actions">
+              <button mat-flat-button color="primary" (click)="createGroup()" [disabled]="!newGroupName.trim()">
+                Create
               </button>
-              <button
-                mat-icon-button
-                class="pm-delete-btn"
-                [attr.aria-label]="'Delete group ' + group.name"
-                (click)="deleteGroup(group.id)">
-                <mat-icon>delete_outline</mat-icon>
-              </button>
+              <button mat-button (click)="cancelCreate()">Cancel</button>
             </div>
           </div>
+        }
 
-          <!-- Members panel -->
-          @if (expandedGroupId() === group.id) {
-            <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
-              @if (group.members.length === 0) {
-                <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
-              }
-              @for (member of group.members; track member) {
-                <div class="pm-member-row">
-                  <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
-                  <span class="pm-member-name">{{ member }}</span>
-                  <button
-                    mat-icon-button
-                    class="pm-member-remove"
-                    [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
-                    (click)="removeGroupMember(group.id, member)">
-                    <mat-icon>close</mat-icon>
-                  </button>
-                </div>
-              }
-              <!-- Add member placeholder -->
-              <div class="pm-add-member-ghost" aria-hidden="true">
-                <mat-icon>person_add</mat-icon>
-                <span>Add member…</span>
+        @if (groups().length === 0 && !showNewGroupForm()) {
+          <p class="pm-empty-state">No groups yet. Create one to share access easily.</p>
+        }
+
+        @for (group of groups(); track group.id) {
+          <div class="pm-group-item">
+
+            <div class="pm-group-row">
+              <span class="pm-group-name">{{ group.name }}</span>
+              <span class="pm-member-count" [attr.aria-label]="group.members.length + ' members'">
+                {{ group.members.length }} member{{ group.members.length !== 1 ? 's' : '' }}
+              </span>
+              <div class="pm-group-actions">
+                <button
+                  mat-icon-button
+                  [attr.aria-label]="(expandedGroupId() === group.id ? 'Collapse' : 'Manage') + ' group ' + group.name"
+                  [attr.aria-expanded]="expandedGroupId() === group.id"
+                  (click)="toggleGroup(group.id)">
+                  <mat-icon>{{ expandedGroupId() === group.id ? 'expand_less' : 'manage_accounts' }}</mat-icon>
+                </button>
+                <button
+                  mat-icon-button
+                  class="pm-delete-btn"
+                  [attr.aria-label]="'Delete group ' + group.name"
+                  (click)="deleteGroup(group.id)">
+                  <mat-icon>delete_outline</mat-icon>
+                </button>
               </div>
             </div>
-          }
 
-        </div>
+            @if (expandedGroupId() === group.id) {
+              <div class="pm-members-panel" role="region" [attr.aria-label]="'Members of ' + group.name">
+                @if (group.members.length === 0) {
+                  <p class="pm-empty-state pm-empty-state--small">No members yet.</p>
+                }
+                @for (member of group.members; track member) {
+                  <div class="pm-member-row">
+                    <mat-icon class="pm-member-icon" aria-hidden="true">person</mat-icon>
+                    <span class="pm-member-name">{{ member }}</span>
+                    <button
+                      mat-icon-button
+                      class="pm-member-remove"
+                      [attr.aria-label]="'Remove ' + member + ' from ' + group.name"
+                      (click)="removeGroupMember(group.id, member)">
+                      <mat-icon>close</mat-icon>
+                    </button>
+                  </div>
+                }
+                <div class="pm-add-member-ghost" aria-hidden="true">
+                  <mat-icon>person_add</mat-icon>
+                  <span>Add member…</span>
+                </div>
+              </div>
+            }
+
+          </div>
+        }
       }
 
     </section>

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.html
@@ -125,12 +125,62 @@
         } @else if (!acls()) {
           <p class="pm-empty-state">Select a record to load its permissions.</p>
         } @else {
+
+          <!-- Read-only summary: who has what level at a glance -->
+          <div class="perm-summary" aria-label="Permission summary">
+            <div class="perm-summary-row">
+              <span class="perm-summary-label perm-summary-label--admin">Admin</span>
+              <span class="perm-summary-pills">
+                @if (subjectsByLevel().admin.length === 0) {
+                  <span class="perm-summary-empty" aria-label="No admin access">—</span>
+                }
+                @for (s of subjectsByLevel().admin; track s) {
+                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                }
+              </span>
+            </div>
+            <div class="perm-summary-row">
+              <span class="perm-summary-label perm-summary-label--update">Update</span>
+              <span class="perm-summary-pills">
+                @if (subjectsByLevel().update.length === 0) {
+                  <span class="perm-summary-empty" aria-label="No update access">—</span>
+                }
+                @for (s of subjectsByLevel().update; track s) {
+                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                }
+              </span>
+            </div>
+            <div class="perm-summary-row">
+              <span class="perm-summary-label perm-summary-label--view">View</span>
+              <span class="perm-summary-pills">
+                @if (subjectsByLevel().view.length === 0) {
+                  <span class="perm-summary-empty" aria-label="No view access">—</span>
+                }
+                @for (s of subjectsByLevel().view; track s) {
+                  <span class="perm-summary-pill">{{ subjectLabels()[s] || s }}</span>
+                }
+              </span>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+
+          <!-- Add access button — above the edit rows -->
+          @if (!showAddPanel()) {
+            <button mat-stroked-button class="pm-add-access-btn"
+                    (click)="openAddPerson()"
+                    aria-label="Add access for a person or group">
+              <mat-icon aria-hidden="true">person_add</mat-icon>
+              Add access
+            </button>
+          }
+
           <!-- Subject list with computed levels -->
           @if (uniqueSubjects().length === 0) {
             <p class="pm-empty-state">No one has access to this record yet.</p>
           }
           @for (subject of uniqueSubjects(); track subject) {
             <div class="pm-subject-row">
+              <mat-icon class="pm-subject-type-icon" aria-hidden="true">{{ isGroup(subject) ? 'corporate_fare' : 'person' }}</mat-icon>
               <span class="pm-subject-name">{{ subjectLabels()[subject] || subject }}</span>
               @if (subjectLevel(subject) !== null) {
                 <mat-form-field appearance="outline" class="pm-level-select-field" subscriptSizing="dynamic">
@@ -151,15 +201,6 @@
                 <mat-icon>person_remove</mat-icon>
               </button>
             </div>
-          }
-
-          @if (!showAddPanel()) {
-            <button mat-stroked-button class="pm-add-access-btn"
-                    (click)="openAddPerson()"
-                    aria-label="Add access for a person or group">
-              <mat-icon aria-hidden="true">person_add</mat-icon>
-              Add access
-            </button>
           }
 
           @if (showAddPanel()) {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -444,6 +444,7 @@ mat-divider {
 
 .pm-add-access-btn {
   margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
   height: 32px;
   font-size: 0.8rem;
 
@@ -453,6 +454,85 @@ mat-divider {
     height: 16px;
     margin-right: 4px;
   }
+}
+
+// --- Permission summary block ---
+
+.perm-summary {
+  padding: 0.35rem 0 0.5rem;
+}
+
+.perm-summary-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  min-height: 28px;
+}
+
+.perm-summary-label {
+  flex-shrink: 0;
+  width: 52px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 0;
+  border-radius: 3px;
+  text-align: center;
+
+  &--admin {
+    background: rgba(198, 40, 40, 0.1);
+    color: #b71c1c;
+  }
+
+  &--update {
+    background: rgba(25, 118, 210, 0.1);
+    color: #1565c0;
+  }
+
+  &--view {
+    background: rgba(0, 0, 0, 0.06);
+    color: rgba(0, 0, 0, 0.55);
+  }
+}
+
+.perm-summary-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+}
+
+.perm-summary-pill {
+  display: inline-block;
+  font-size: 0.75rem;
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.07);
+  white-space: nowrap;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.perm-summary-empty {
+  font-size: 0.8rem;
+  opacity: 0.3;
+  line-height: 1.6;
+}
+
+// --- Subject row type icon ---
+
+.pm-subject-type-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  opacity: 0.45;
+  color: inherit;
 }
 
 .pm-level-field {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -68,3 +68,156 @@
   border: 1px solid rgba(0, 0, 0, 0.12);
   flex-shrink: 0;
 }
+
+// --- Shared section layout ---
+
+.pm-section {
+  padding: 0.5rem 0;
+}
+
+.pm-section-title {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.6;
+}
+
+mat-divider {
+  margin: 0.25rem 0;
+}
+
+// --- My Groups ---
+
+.pm-groups-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0 0.5rem;
+}
+
+.pm-new-group-btn {
+  height: 32px;
+  font-size: 0.8rem;
+}
+
+.pm-new-group-form {
+  padding: 0.25rem 0 0.5rem;
+}
+
+.pm-group-name-field {
+  width: 100%;
+}
+
+.pm-form-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.pm-empty-state {
+  font-size: 0.85rem;
+  opacity: 0.55;
+  padding: 0.5rem 0;
+  margin: 0;
+
+  &--small {
+    padding: 0.25rem 0.5rem;
+  }
+}
+
+.pm-group-item {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  overflow: hidden;
+}
+
+.pm-group-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem 0.4rem 0.75rem;
+}
+
+.pm-group-name {
+  flex: 1;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.pm-member-count {
+  font-size: 0.75rem;
+  opacity: 0.55;
+  flex-shrink: 0;
+}
+
+.pm-group-actions {
+  display: flex;
+  gap: 0;
+}
+
+.pm-delete-btn {
+  color: rgba(0, 0, 0, 0.35);
+
+  &:hover {
+    color: #c62828;
+  }
+}
+
+.pm-members-panel {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.02);
+  padding: 0.25rem 0.5rem 0.5rem;
+}
+
+.pm-member-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+
+.pm-member-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  opacity: 0.45;
+}
+
+.pm-member-name {
+  flex: 1;
+  font-size: 0.85rem;
+}
+
+.pm-member-remove {
+  width: 28px;
+  height: 28px;
+  line-height: 28px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.pm-add-member-ghost {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.25rem;
+  margin-top: 0.25rem;
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  font-size: 0.82rem;
+  opacity: 0.45;
+  cursor: default;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -183,6 +183,17 @@
   }
 }
 
+.pm-org-type-badge {
+  display: inline-block;
+  margin-left: 0.4em;
+  font-size: 0.7em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.55;
+  vertical-align: middle;
+}
+
 .pm-add-person-actions {
   display: flex;
   gap: 0.5rem;
@@ -304,14 +315,13 @@ mat-divider {
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 6px;
   margin-bottom: 0.5rem;
-  overflow: hidden;
 }
 
 .pm-group-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.4rem 0.5rem 0.4rem 0.75rem;
+  padding: 0.4rem 0.25rem 0.4rem 0.75rem;
 }
 
 .pm-group-name {
@@ -342,14 +352,15 @@ mat-divider {
 .pm-members-panel {
   border-top: 1px solid rgba(0, 0, 0, 0.08);
   background: rgba(0, 0, 0, 0.02);
-  padding: 0.25rem 0.5rem 0.5rem;
+  padding: 0.25rem 0.25rem 0.25rem 0.5rem;
+  border-radius: 0 0 6px 6px;
 }
 
 .pm-member-row {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.2rem 0;
+  padding: 0.1rem 0;
 }
 
 .pm-member-icon {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -48,6 +48,9 @@
   display: flex;
   gap: 0.4rem;
   flex: 1;
+  flex-wrap: wrap;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .pm-chip-ghost {
@@ -67,6 +70,123 @@
   border-radius: 4px;
   border: 1px solid rgba(0, 0, 0, 0.12);
   flex-shrink: 0;
+}
+
+.pm-add-person-btn {
+  flex-shrink: 0;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+
+  &:hover, &--active {
+    opacity: 1;
+  }
+}
+
+.pm-add-person-panel {
+  margin: 0 0 0.5rem 0;
+  padding: 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.015);
+}
+
+.pm-staged-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.pm-people-field {
+  width: 100%;
+}
+
+.pm-group-field {
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
+.pm-org-units {
+  margin-top: 0.25rem;
+}
+
+.pm-loading--small {
+  padding: 0.25rem 0;
+  font-size: 0.8rem;
+}
+
+.pm-nist-groups {
+  padding: 0.5rem 0;
+}
+
+.pm-nist-org-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+}
+
+.pm-nist-org-icon {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+.pm-nist-org-name {
+  font-size: 0.85rem;
+}
+
+.pm-group-option-btn--nist {
+  border-color: rgba(0, 0, 0, 0.18);
+  color: rgba(0, 0, 0, 0.65);
+}
+
+.pm-group-options {
+  margin-top: 0.5rem;
+}
+
+.pm-group-options-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.5;
+  margin-bottom: 0.35rem;
+}
+
+.pm-group-option-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.pm-group-option-btn {
+  height: 28px;
+  font-size: 0.8rem;
+  line-height: 28px;
+  padding: 0 0.6rem;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    margin-right: 4px;
+  }
+
+  &--staged {
+    background: rgba(25, 118, 210, 0.1);
+    border-color: #1976d2;
+    color: #1976d2;
+  }
+}
+
+.pm-add-person-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
 }
 
 // --- Loading / error states ---
@@ -90,6 +210,30 @@
   font-size: 0.85rem;
   opacity: 0.55;
   margin: 0.25rem 0;
+}
+
+.pm-bulk-panel {
+  padding: 0.25rem 0;
+}
+
+.pm-bulk-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    opacity: 0.6;
+  }
+}
+
+.pm-perm-select-field {
+  width: 100%;
+  margin-bottom: 0.25rem;
 }
 
 .pm-perm-empty {
@@ -221,32 +365,97 @@ mat-divider {
 }
 
 .pm-member-remove {
-  width: 28px;
-  height: 28px;
-  line-height: 28px;
+  --mdc-icon-button-state-layer-size: 28px;
+  --mdc-icon-button-icon-size: 18px;
+  flex-shrink: 0;
+}
 
-  mat-icon {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
+.pm-add-member-form {
+  margin-top: 0.25rem;
+}
+
+.pm-add-member-field {
+  width: 100%;
+}
+
+// --- Graduated model subject rows ---
+
+.pm-subject-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+
+  &:last-of-type {
+    border-bottom: none;
   }
 }
 
-.pm-add-member-ghost {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.3rem 0.25rem;
-  margin-top: 0.25rem;
-  border: 1px dashed rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-  font-size: 0.82rem;
-  opacity: 0.45;
-  cursor: default;
+.pm-subject-name {
+  flex: 1;
+  font-size: 0.875rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pm-level-select-field {
+  width: 110px;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+
+  // Compact the mat-form-field for inline row use
+  .mat-mdc-form-field-infix {
+    padding-top: 4px;
+    padding-bottom: 4px;
+    min-height: unset;
+  }
+  .mat-mdc-text-field-wrapper {
+    padding: 0 8px;
+  }
+}
+
+.pm-level-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 7px;
+  border-radius: 3px;
+  flex-shrink: 0;
+
+  &--custom {
+    background: rgba(0, 0, 0, 0.07);
+    color: rgba(0, 0, 0, 0.5);
+  }
+}
+
+.pm-remove-btn {
+  flex-shrink: 0;
+  color: rgba(0, 0, 0, 0.3);
+
+  &:hover {
+    color: #c62828;
+  }
+}
+
+.pm-add-access-btn {
+  margin-top: 0.5rem;
+  height: 32px;
+  font-size: 0.8rem;
 
   mat-icon {
     font-size: 16px;
     width: 16px;
     height: 16px;
+    margin-right: 4px;
   }
+}
+
+.pm-level-field {
+  width: 100%;
+  margin-top: 0.25rem;
 }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -69,6 +69,35 @@
   flex-shrink: 0;
 }
 
+// --- Loading / error states ---
+
+.pm-loading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.85rem;
+  opacity: 0.65;
+}
+
+.pm-error {
+  font-size: 0.85rem;
+  color: #c62828;
+  margin: 0.25rem 0;
+}
+
+.pm-multi-hint {
+  font-size: 0.85rem;
+  opacity: 0.55;
+  margin: 0.25rem 0;
+}
+
+.pm-perm-empty {
+  font-size: 0.8rem;
+  opacity: 0.35;
+  align-self: center;
+}
+
 // --- Shared section layout ---
 
 .pm-section {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -378,108 +378,26 @@ mat-divider {
   width: 100%;
 }
 
-// --- Graduated model subject rows ---
+// --- Chip layout (levels grouped) ---
 
-.pm-subject-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
-
-  &:last-of-type {
-    border-bottom: none;
-  }
+.pm-levels {
+  padding: 0.25rem 0 0.5rem;
 }
 
-.pm-subject-name {
-  flex: 1;
-  font-size: 0.875rem;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.pm-level-section {
+  margin-bottom: 16px;
 }
 
-.pm-level-select-field {
-  width: 110px;
-  flex-shrink: 0;
-  font-size: 0.8rem;
-
-  // Compact the mat-form-field for inline row use
-  .mat-mdc-form-field-infix {
-    padding-top: 4px;
-    padding-bottom: 4px;
-    min-height: unset;
-  }
-  .mat-mdc-text-field-wrapper {
-    padding: 0 8px;
-  }
-}
-
-.pm-level-badge {
-  display: inline-block;
+.pm-level-header {
+  display: block;
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 2px 7px;
+  letter-spacing: 0.07em;
+  margin-bottom: 6px;
+  padding: 2px 6px;
   border-radius: 3px;
-  flex-shrink: 0;
-
-  &--custom {
-    background: rgba(0, 0, 0, 0.07);
-    color: rgba(0, 0, 0, 0.5);
-  }
-}
-
-.pm-remove-btn {
-  flex-shrink: 0;
-  color: rgba(0, 0, 0, 0.3);
-
-  &:hover {
-    color: #c62828;
-  }
-}
-
-.pm-add-access-btn {
-  margin-top: 0.5rem;
-  margin-bottom: 0.25rem;
-  height: 32px;
-  font-size: 0.8rem;
-
-  mat-icon {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
-    margin-right: 4px;
-  }
-}
-
-// --- Permission summary block ---
-
-.perm-summary {
-  padding: 0.35rem 0 0.5rem;
-}
-
-.perm-summary-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.25rem 0;
-  min-height: 28px;
-}
-
-.perm-summary-label {
-  flex-shrink: 0;
-  width: 52px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  padding: 3px 0;
-  border-radius: 3px;
-  text-align: center;
+  width: fit-content;
 
   &--admin {
     background: rgba(198, 40, 40, 0.1);
@@ -497,42 +415,118 @@ mat-divider {
   }
 }
 
-.perm-summary-pills {
+.pm-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
-  flex: 1;
-  min-width: 0;
+  gap: 6px;
+  margin-top: 4px;
+  min-height: 26px;
   align-items: center;
 }
 
-.perm-summary-pill {
-  display: inline-block;
-  font-size: 0.75rem;
-  padding: 1px 8px;
-  border-radius: 10px;
-  background: rgba(0, 0, 0, 0.07);
-  white-space: nowrap;
-  max-width: 180px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.pm-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 16px;
+  padding: 2px 4px 2px 4px;
+  font-size: 0.82rem;
+  line-height: 1;
+
+  &--admin {
+    background: rgba(198, 40, 40, 0.08);
+    border: 1px solid rgba(183, 28, 28, 0.2);
+  }
+
+  &--update {
+    background: rgba(25, 118, 210, 0.08);
+    border: 1px solid rgba(21, 101, 192, 0.2);
+  }
+
+  &--view {
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
 }
 
-.perm-summary-empty {
+.pm-chip-icon {
+  font-size: 13px;
+  width: 13px;
+  height: 13px;
+  opacity: 0.5;
+  margin-right: 3px;
+  flex-shrink: 0;
+}
+
+.pm-chip-label {
+  background: none;
+  border: none;
+  padding: 2px 4px 2px 2px;
+  font-size: inherit;
+  cursor: pointer;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 12px;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 1px;
+  }
+}
+
+.pm-chip-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 1px 4px 1px 2px;
+  color: rgba(0, 0, 0, 0.4);
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+
+  &:hover {
+    color: #c62828;
+    background: rgba(198, 40, 40, 0.1);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #c62828;
+    outline-offset: 1px;
+  }
+}
+
+.pm-chips-empty {
   font-size: 0.8rem;
   opacity: 0.3;
   line-height: 1.6;
 }
 
-// --- Subject row type icon ---
+// --- Add access section ---
 
-.pm-subject-type-icon {
-  font-size: 16px;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-  opacity: 0.45;
-  color: inherit;
+.pm-add-section {
+  margin-top: 0.5rem;
+}
+
+.pm-add-access-btn {
+  height: 32px;
+  font-size: 0.8rem;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+  }
 }
 
 .pm-level-field {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.scss
@@ -1,0 +1,70 @@
+:host {
+  display: block;
+}
+
+.pm-card {
+  width: 100%;
+}
+
+.pm-stub-badge {
+  display: inline-block;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  background: #1976d2;
+  color: #fff;
+  padding: 1px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
+.pm-perm-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.pm-perm-label {
+  width: 56px;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.55;
+}
+
+.pm-perm-chips {
+  display: flex;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.pm-chip-ghost {
+  height: 22px;
+  width: 72px;
+  border-radius: 11px;
+  background: rgba(0, 0, 0, 0.07);
+
+  &--short {
+    width: 52px;
+  }
+}
+
+.pm-add-ghost {
+  height: 28px;
+  width: 120px;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  flex-shrink: 0;
+}

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -630,4 +630,59 @@ describe('PermissionManagerComponent', () => {
       expect(component.LEVEL_PERMS['admin']).toEqual(['read', 'write', 'admin', 'delete'])
     })
   })
+
+  // ── loadNistOrgs — subject prefix ─────────────────────────────────────────
+
+  describe('loadNistOrgs — subject prefix', () => {
+    beforeEach(() => {
+      // Provide an orgURL so loadNistOrgs doesn't bail out early
+      jest.spyOn((component as any).configSvc, 'getConfig').mockReturnValue({ orgURL: 'https://orgs.example.com/api' })
+    })
+
+    it('stages a NIST ou org with nistou: prefix', () => {
+      // org name contains 'mml' so the name-based filter passes
+      const orgApiResponse = { ou: { '728': 'MML Materials Division' } }
+      jest.spyOn((component as any).http, 'get').mockReturnValue(of(orgApiResponse))
+
+      component.loadNistOrgs('MML')
+
+      expect(component.nistOrgs()).toContainEqual({ id: 'nistou:728', name: 'MML Materials Division' })
+    })
+
+    it('stages a NIST div org with nistdiv: prefix', () => {
+      // org name contains 'itl' so the name-based filter passes
+      const orgApiResponse = { div: { '456': 'ITL Applied Cybersecurity Division' } }
+      jest.spyOn((component as any).http, 'get').mockReturnValue(of(orgApiResponse))
+
+      component.loadNistOrgs('ITL')
+
+      expect(component.nistOrgs()).toContainEqual({ id: 'nistdiv:456', name: 'ITL Applied Cybersecurity Division' })
+    })
+
+    it('falls back to the raw key as prefix for unknown org types', () => {
+      // org name contains 'x' so the name-based filter passes
+      const orgApiResponse = { custom: { '999': 'X Unknown Org' } }
+      jest.spyOn((component as any).http, 'get').mockReturnValue(of(orgApiResponse))
+
+      component.loadNistOrgs('X')
+
+      expect(component.nistOrgs()).toContainEqual({ id: 'custom:999', name: 'X Unknown Org' })
+    })
+  })
+
+  // ── ngOnChanges dedup ──────────────────────────────────────────────────────
+
+  describe('ngOnChanges', () => {
+    it('calls loadGroups() once when records and section=groups both change simultaneously', () => {
+      const loadGroupsSpy = jest.spyOn(component, 'loadGroups')
+      component.section = 'groups'
+
+      component.ngOnChanges({
+        records: { currentValue: [{ id: 'r1', apiBase: 'https://api/' }], previousValue: [], firstChange: false, isFirstChange: () => false },
+        section: { currentValue: 'groups', previousValue: 'permissions', firstChange: false, isFirstChange: () => false },
+      })
+
+      expect(loadGroupsSpy).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -272,6 +272,23 @@ describe('PermissionManagerComponent', () => {
       component.removeSubject('alice')
       expect(permsSvc.revokePerm).not.toHaveBeenCalled()
     })
+
+    it('calls loadAcls() and emits even when one revoke errors', () => {
+      permsSvc.revokePerm
+        .mockReturnValueOnce(throwError(() => new Error('500')))
+        .mockReturnValue(of({ read: [], write: [], admin: [], delete: [] }))
+
+      component.acls.set({ read: ['alice'], write: ['alice'], admin: [], delete: [] })
+      permsSvc.getAcls.mockReturnValue(of({ read: [], write: [], admin: [], delete: [] }))
+      const spy = jest.spyOn(component.permissionsChanged, 'emit')
+
+      component.removeSubject('alice')
+
+      // forkJoin fails fast; error path must call loadAcls
+      expect(permsSvc.getAcls).toHaveBeenCalled()
+      // permissionsChanged does NOT emit on error (partial failure = unknown state)
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 
   // ── grantStagedLevel() ─────────────────────────────────────────────────────

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -346,6 +346,38 @@ describe('PermissionManagerComponent', () => {
       component.grantStagedLevel('admin')
       expect(permsSvc.grantPerm).not.toHaveBeenCalled()
     })
+
+    it('calls loadAcls() exactly once even when 3 people are staged', () => {
+      const record: RecordRef = { id: 'mdm:001', apiBase: 'https://api/' }
+      fixture.componentRef.setInput('records', [record])
+      component.acls.set({ read: [], write: [], admin: [], delete: [] })
+      component.staged.set([
+        { id: 'alice', label: 'Alice' },
+        { id: 'bob', label: 'Bob' },
+        { id: 'carol', label: 'Carol' },
+      ])
+      permsSvc.grantPerm.mockReturnValue(of(['alice']))
+      permsSvc.getAcls.mockReturnValue(of({ read: ['alice', 'bob', 'carol'], write: [], admin: [], delete: [] }))
+
+      component.grantStagedLevel('view')
+
+      expect(permsSvc.getAcls).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls loadAcls() and does NOT emit when any op errors', () => {
+      const record: RecordRef = { id: 'mdm:001', apiBase: 'https://api/' }
+      fixture.componentRef.setInput('records', [record])
+      component.acls.set({ read: [], write: [], admin: [], delete: [] })
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      permsSvc.grantPerm.mockReturnValue(throwError(() => new Error('403')))
+      permsSvc.getAcls.mockReturnValue(of({ read: [], write: [], admin: [], delete: [] }))
+      const spy = jest.spyOn(component.permissionsChanged, 'emit')
+
+      component.grantStagedLevel('view')
+
+      expect(permsSvc.getAcls).toHaveBeenCalled()
+      expect(spy).not.toHaveBeenCalled()
+    })
   })
 
   // ── grantBulk() ────────────────────────────────────────────────────────────

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -1,0 +1,66 @@
+import { of } from 'rxjs'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { PermissionManagerComponent } from './permission-manager.component'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
+import { MatDialogModule } from '@angular/material/dialog'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { ConfigurationService } from '../../config/config.service'
+import { PermissionsService } from '../permissions.service'
+import { GroupsService } from '../groups.service'
+import { Acls } from '../group.types'
+
+describe('PermissionManagerComponent', () => {
+  let component: PermissionManagerComponent
+  let fixture: ComponentFixture<PermissionManagerComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PermissionManagerComponent],
+      imports: [HttpClientTestingModule, MatDialogModule, NoopAnimationsModule],
+      providers: [
+        { provide: ConfigurationService, useValue: { getConfig: () => ({}) } },
+        { provide: PermissionsService, useValue: { grantPerm: jest.fn(), revokePerm: jest.fn(), getAcls: jest.fn() } },
+        { provide: GroupsService, useValue: { getGroups: jest.fn(() => of([])) } },
+      ]
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(PermissionManagerComponent)
+    component = fixture.componentInstance
+  })
+
+  describe('subjectLevel()', () => {
+    const makeAcls = (r: string[], w: string[], a: string[], d: string[]): Acls =>
+      ({ read: r, write: w, admin: a, delete: d })
+
+    it('returns admin when subject has all four permissions', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      expect(component.subjectLevel('alice')).toBe('admin')
+    })
+
+    it('returns update when subject has read and write but not admin/delete', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], [], []))
+      expect(component.subjectLevel('alice')).toBe('update')
+    })
+
+    it('returns update even when subject has extra permissions above read+write', () => {
+      // has read+write+admin but not delete: highest FULLY compatible level is update
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], []))
+      expect(component.subjectLevel('alice')).toBe('update')
+    })
+
+    it('returns view when subject has only read', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      expect(component.subjectLevel('alice')).toBe('view')
+    })
+
+    it('returns null when subject has no read permission', () => {
+      component.acls.set(makeAcls([], ['alice'], [], []))
+      expect(component.subjectLevel('alice')).toBeNull()
+    })
+
+    it('returns null when subject is not present', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      expect(component.subjectLevel('bob')).toBeNull()
+    })
+  })
+})

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -1,4 +1,4 @@
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { PermissionManagerComponent } from './permission-manager.component'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
@@ -7,20 +7,47 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { ConfigurationService } from '../../config/config.service'
 import { PermissionsService } from '../permissions.service'
 import { GroupsService } from '../groups.service'
-import { Acls } from '../group.types'
+import { Acls, Group, RecordRef } from '../group.types'
+
+const RECORD: RecordRef = { id: 'mdm1:0001', apiBase: 'https://api.example.com' }
+const EMPTY_ACLS: Acls = { read: [], write: [], admin: [], delete: [] }
+
+const makeAcls = (r: string[], w: string[], a: string[], d: string[]): Acls =>
+  ({ read: r, write: w, admin: a, delete: d })
 
 describe('PermissionManagerComponent', () => {
   let component: PermissionManagerComponent
   let fixture: ComponentFixture<PermissionManagerComponent>
+  let permsSvc: { grantPerm: jest.Mock; revokePerm: jest.Mock; getAcls: jest.Mock }
+  let groupsSvc: {
+    getGroups: jest.Mock
+    createGroup: jest.Mock
+    deleteGroup: jest.Mock
+    addMember: jest.Mock
+    removeMember: jest.Mock
+  }
 
   beforeEach(async () => {
+    permsSvc = {
+      grantPerm: jest.fn().mockReturnValue(of(['alice'])),
+      revokePerm: jest.fn().mockReturnValue(of(EMPTY_ACLS)),
+      getAcls: jest.fn().mockReturnValue(of(EMPTY_ACLS)),
+    }
+    groupsSvc = {
+      getGroups: jest.fn().mockReturnValue(of([])),
+      createGroup: jest.fn().mockReturnValue(of({ id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] })),
+      deleteGroup: jest.fn().mockReturnValue(of('deleted')),
+      addMember: jest.fn().mockReturnValue(of(['alice'])),
+      removeMember: jest.fn().mockReturnValue(of('removed')),
+    }
+
     await TestBed.configureTestingModule({
       declarations: [PermissionManagerComponent],
       imports: [HttpClientTestingModule, MatDialogModule, NoopAnimationsModule],
       providers: [
         { provide: ConfigurationService, useValue: { getConfig: () => ({}) } },
-        { provide: PermissionsService, useValue: { grantPerm: jest.fn(), revokePerm: jest.fn(), getAcls: jest.fn() } },
-        { provide: GroupsService, useValue: { getGroups: jest.fn(() => of([])) } },
+        { provide: PermissionsService, useValue: permsSvc },
+        { provide: GroupsService, useValue: groupsSvc },
       ]
     }).compileComponents()
 
@@ -28,10 +55,9 @@ describe('PermissionManagerComponent', () => {
     component = fixture.componentInstance
   })
 
-  describe('subjectLevel()', () => {
-    const makeAcls = (r: string[], w: string[], a: string[], d: string[]): Acls =>
-      ({ read: r, write: w, admin: a, delete: d })
+  // ── subjectLevel() ─────────────────────────────────────────────────────────
 
+  describe('subjectLevel()', () => {
     it('returns admin when subject has all four permissions', () => {
       component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
       expect(component.subjectLevel('alice')).toBe('admin')
@@ -42,8 +68,7 @@ describe('PermissionManagerComponent', () => {
       expect(component.subjectLevel('alice')).toBe('update')
     })
 
-    it('returns update even when subject has extra permissions above read+write', () => {
-      // has read+write+admin but not delete: highest FULLY compatible level is update
+    it('returns update even when subject has read+write+admin but not delete', () => {
       component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], []))
       expect(component.subjectLevel('alice')).toBe('update')
     })
@@ -58,9 +83,467 @@ describe('PermissionManagerComponent', () => {
       expect(component.subjectLevel('alice')).toBeNull()
     })
 
-    it('returns null when subject is not present', () => {
+    it('returns null when subject is not present in any list', () => {
       component.acls.set(makeAcls(['alice'], [], [], []))
       expect(component.subjectLevel('bob')).toBeNull()
+    })
+
+    it('returns null when acls is null', () => {
+      component.acls.set(null)
+      expect(component.subjectLevel('alice')).toBeNull()
+    })
+  })
+
+  // ── uniqueSubjects computed ────────────────────────────────────────────────
+
+  describe('uniqueSubjects', () => {
+    it('returns empty array when acls is null', () => {
+      component.acls.set(null)
+      expect(component.uniqueSubjects()).toEqual([])
+    })
+
+    it('returns all unique subjects across all perm arrays', () => {
+      component.acls.set(makeAcls(['alice', 'bob'], ['alice'], ['alice'], ['alice']))
+      const subjects = component.uniqueSubjects()
+      expect(subjects).toContain('alice')
+      expect(subjects).toContain('bob')
+      expect(subjects).toHaveLength(2)
+    })
+
+    it('deduplicates subjects appearing in multiple perm arrays', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      expect(component.uniqueSubjects()).toEqual(['alice'])
+    })
+
+    it('includes subjects from all four perm arrays', () => {
+      component.acls.set(makeAcls(['r-only'], ['w-only'], ['a-only'], ['d-only']))
+      const subjects = component.uniqueSubjects()
+      expect(subjects).toHaveLength(4)
+      expect(subjects).toContain('r-only')
+      expect(subjects).toContain('w-only')
+      expect(subjects).toContain('a-only')
+      expect(subjects).toContain('d-only')
+    })
+  })
+
+  // ── subjectsFor() ──────────────────────────────────────────────────────────
+
+  describe('subjectsFor()', () => {
+    it('returns the read array from acls', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      expect(component.subjectsFor('read')).toEqual(['alice'])
+    })
+
+    it('returns the correct array for each perm type', () => {
+      component.acls.set(makeAcls(['r'], ['w'], ['a'], ['d']))
+      expect(component.subjectsFor('read')).toEqual(['r'])
+      expect(component.subjectsFor('write')).toEqual(['w'])
+      expect(component.subjectsFor('admin')).toEqual(['a'])
+      expect(component.subjectsFor('delete')).toEqual(['d'])
+    })
+
+    it('returns empty array when acls is null', () => {
+      component.acls.set(null)
+      expect(component.subjectsFor('read')).toEqual([])
+    })
+  })
+
+  // ── setSubjectLevel() ──────────────────────────────────────────────────────
+
+  describe('setSubjectLevel()', () => {
+    beforeEach(() => {
+      component.singleRecord.set(RECORD)
+    })
+
+    it('grants missing perms when upgrading to admin', () => {
+      // alice has view; upgrading to admin requires granting write, admin, delete
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      component.setSubjectLevel('alice', 'admin')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'admin', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'delete', 'alice')
+      expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+    })
+
+    it('revokes excess perms when downgrading to view', () => {
+      // alice has admin (all four); downgrading to view requires revoking write, admin, delete
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      component.setSubjectLevel('alice', 'view')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'admin', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'delete', 'alice')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+
+    it('both grants and revokes when switching from view to update', () => {
+      // alice has only read; upgrade to update requires granting write
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      component.setSubjectLevel('alice', 'update')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when the subject is already at the target level', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      component.setSubjectLevel('alice', 'admin')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+      expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+    })
+
+    it('emits permissionsChanged after all ops complete', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.setSubjectLevel('alice', 'admin')
+      expect(component.permissionsChanged.emit).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not emit permissionsChanged when emitChange is false', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.setSubjectLevel('alice', 'admin', false)
+      expect(component.permissionsChanged.emit).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when singleRecord is null', () => {
+      component.singleRecord.set(null)
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      component.setSubjectLevel('alice', 'admin')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when acls is null', () => {
+      component.acls.set(null)
+      component.setSubjectLevel('alice', 'admin')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+
+    it('calls loadAcls() even when an operation errors', () => {
+      permsSvc.revokePerm.mockReturnValue(throwError(() => new Error('403')))
+      permsSvc.grantPerm.mockReturnValue(of(['alice']))
+
+      // alice has read + write but NOT admin/delete — upgrading to admin triggers grants
+      component.acls.set(makeAcls(['alice'], ['alice'], [], []))
+      // mock getAcls for loadAcls()
+      permsSvc.getAcls.mockReturnValue(of({ read: ['alice'], write: ['alice'], admin: ['alice'], delete: ['alice'] }))
+
+      component.setSubjectLevel('alice', 'admin')
+
+      // forkJoin error path — loadAcls must be called
+      expect(permsSvc.getAcls).toHaveBeenCalled()
+    })
+  })
+
+  // ── removeSubject() ────────────────────────────────────────────────────────
+
+  describe('removeSubject()', () => {
+    beforeEach(() => {
+      component.singleRecord.set(RECORD)
+    })
+
+    it('revokes all perms the subject holds', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], [], []))
+      component.removeSubject('alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'read', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledTimes(2)
+    })
+
+    it('revokes all four perms for an admin subject', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      component.removeSubject('alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledTimes(4)
+    })
+
+    it('emits permissionsChanged when all revokes complete', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], [], []))
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.removeSubject('alice')
+      expect(component.permissionsChanged.emit).toHaveBeenCalledTimes(1)
+    })
+
+    it('is a no-op when subject is not in any ACL list', () => {
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      component.removeSubject('bob')
+      expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when singleRecord is null', () => {
+      component.singleRecord.set(null)
+      component.acls.set(makeAcls(['alice'], [], [], []))
+      component.removeSubject('alice')
+      expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── grantStagedLevel() ─────────────────────────────────────────────────────
+
+  describe('grantStagedLevel()', () => {
+    beforeEach(() => {
+      component.singleRecord.set(RECORD)
+      component.acls.set(EMPTY_ACLS)
+    })
+
+    it('grants the required perms for each staged person', () => {
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.grantStagedLevel('view')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'read', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledTimes(1)
+    })
+
+    it('grants all four perms when level is admin', () => {
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.grantStagedLevel('admin')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'read', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'admin', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'delete', 'alice')
+    })
+
+    it('emits permissionsChanged once when all staged people are processed', () => {
+      component.staged.set([
+        { id: 'alice', label: 'Alice' },
+        { id: 'bob', label: 'Bob' },
+      ])
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.grantStagedLevel('view')
+      expect(component.permissionsChanged.emit).toHaveBeenCalledTimes(1)
+    })
+
+    it('revokes excess perms when downgrading an existing subject', () => {
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.grantStagedLevel('view')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'admin', 'alice')
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(RECORD, 'delete', 'alice')
+    })
+
+    it('is a no-op when staged is empty', () => {
+      component.staged.set([])
+      component.grantStagedLevel('admin')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when singleRecord is null', () => {
+      component.singleRecord.set(null)
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.grantStagedLevel('admin')
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── grantBulk() ────────────────────────────────────────────────────────────
+
+  describe('grantBulk()', () => {
+    beforeEach(() => {
+      component.records = [RECORD]
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.bulkLevel = 'update'
+    })
+
+    it('calls grantPerm for each person × record × required perm', () => {
+      component.grantBulk()
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'read', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'write', 'alice')
+      expect(permsSvc.grantPerm).toHaveBeenCalledTimes(2)
+    })
+
+    it('emits permissionsChanged when all operations succeed', () => {
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.grantBulk()
+      expect(component.permissionsChanged.emit).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears staged list on success', () => {
+      component.grantBulk()
+      expect(component.staged()).toEqual([])
+    })
+
+    it('sets bulkGrantError when any operation fails', () => {
+      permsSvc.grantPerm
+        .mockReturnValueOnce(of(['alice']))
+        .mockReturnValueOnce(throwError(() => new Error('network error')))
+      component.grantBulk()
+      expect(component.bulkGrantError()).toMatch(/operation/)
+    })
+
+    it('does not emit permissionsChanged on partial failure', () => {
+      permsSvc.grantPerm
+        .mockReturnValueOnce(of(['alice']))
+        .mockReturnValueOnce(throwError(() => new Error('network error')))
+      jest.spyOn(component.permissionsChanged, 'emit')
+      component.grantBulk()
+      expect(component.permissionsChanged.emit).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when staged is empty', () => {
+      component.staged.set([])
+      component.grantBulk()
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when records is empty', () => {
+      component.records = []
+      component.grantBulk()
+      expect(permsSvc.grantPerm).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── loadAcls() ─────────────────────────────────────────────────────────────
+
+  describe('loadAcls()', () => {
+    it('calls getAcls with singleRecord and sets acls on success', () => {
+      const acls = makeAcls(['alice'], [], [], [])
+      permsSvc.getAcls.mockReturnValueOnce(of(acls))
+      component.singleRecord.set(RECORD)
+      component.loadAcls()
+      expect(permsSvc.getAcls).toHaveBeenCalledWith(RECORD)
+      expect(component.acls()).toEqual(acls)
+    })
+
+    it('clears aclsLoading after success', () => {
+      component.singleRecord.set(RECORD)
+      component.loadAcls()
+      expect(component.aclsLoading()).toBe(false)
+    })
+
+    it('sets aclsError and clears loading on error', () => {
+      permsSvc.getAcls.mockReturnValueOnce(throwError(() => new Error('server error')))
+      component.singleRecord.set(RECORD)
+      component.loadAcls()
+      expect(component.aclsError()).toBe('Could not load permissions.')
+      expect(component.aclsLoading()).toBe(false)
+    })
+
+    it('sets acls to null and skips the request when singleRecord is null', () => {
+      component.singleRecord.set(null)
+      component.loadAcls()
+      expect(permsSvc.getAcls).not.toHaveBeenCalled()
+      expect(component.acls()).toBeNull()
+    })
+  })
+
+  // ── loadGroups() ───────────────────────────────────────────────────────────
+
+  describe('loadGroups()', () => {
+    it('calls getGroups and sets groups signal on success', () => {
+      const groups: Group[] = [{ id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] }]
+      groupsSvc.getGroups.mockReturnValueOnce(of(groups))
+      component.loadGroups()
+      expect(component.groups()).toEqual(groups)
+    })
+
+    it('clears groupsLoading after success', () => {
+      component.loadGroups()
+      expect(component.groupsLoading()).toBe(false)
+    })
+
+    it('sets groupsError and clears loading on error', () => {
+      groupsSvc.getGroups.mockReturnValueOnce(throwError(() => new Error('network error')))
+      component.loadGroups()
+      expect(component.groupsError()).toBe('Could not load groups.')
+      expect(component.groupsLoading()).toBe(false)
+    })
+  })
+
+  // ── staging ────────────────────────────────────────────────────────────────
+
+  describe('staging helpers', () => {
+    describe('unstage()', () => {
+      it('removes the subject from staged', () => {
+        component.staged.set([
+          { id: 'alice', label: 'Alice' },
+          { id: 'bob', label: 'Bob' },
+        ])
+        component.unstage('alice')
+        expect(component.staged()).toEqual([{ id: 'bob', label: 'Bob' }])
+      })
+
+      it('is a no-op when subject is not staged', () => {
+        component.staged.set([{ id: 'alice', label: 'Alice' }])
+        component.unstage('carol')
+        expect(component.staged()).toHaveLength(1)
+      })
+    })
+
+    describe('stageGroup() / isGroupStaged()', () => {
+      it('stageGroup adds the group to staged', () => {
+        const group: Group = { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] }
+        component.stageGroup(group)
+        expect(component.isGroupStaged('grp0:alice:team')).toBe(true)
+      })
+
+      it('isGroupStaged returns false when group is not staged', () => {
+        expect(component.isGroupStaged('grp0:alice:team')).toBe(false)
+      })
+
+      it('stageGroup does not add the same group twice', () => {
+        const group: Group = { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] }
+        component.stageGroup(group)
+        component.stageGroup(group)
+        expect(component.staged()).toHaveLength(1)
+      })
+    })
+
+    describe('stageGroup updates subjectLabels', () => {
+      it('stores the group name in subjectLabels keyed by group id', () => {
+        const group: Group = { id: 'grp0:alice:team', name: 'My Team', owner: 'alice', members: [] }
+        component.stageGroup(group)
+        expect(component.subjectLabels()['grp0:alice:team']).toBe('My Team')
+      })
+    })
+  })
+
+  // ── toggleGroup() ──────────────────────────────────────────────────────────
+
+  describe('toggleGroup()', () => {
+    it('sets expandedGroupId to the given id', () => {
+      component.toggleGroup('grp0:alice:team')
+      expect(component.expandedGroupId()).toBe('grp0:alice:team')
+    })
+
+    it('collapses when the same id is toggled again', () => {
+      component.toggleGroup('grp0:alice:team')
+      component.toggleGroup('grp0:alice:team')
+      expect(component.expandedGroupId()).toBeNull()
+    })
+
+    it('switches to a different group when a new id is toggled', () => {
+      component.toggleGroup('grp0:alice:team')
+      component.toggleGroup('grp0:alice:other')
+      expect(component.expandedGroupId()).toBe('grp0:alice:other')
+    })
+  })
+
+  // ── cancelCreate() ─────────────────────────────────────────────────────────
+
+  describe('cancelCreate()', () => {
+    it('clears newGroupName', () => {
+      component.newGroupName = 'Draft'
+      component.cancelCreate()
+      expect(component.newGroupName).toBe('')
+    })
+
+    it('hides the new group form', () => {
+      component.showNewGroupForm.set(true)
+      component.cancelCreate()
+      expect(component.showNewGroupForm()).toBe(false)
+    })
+  })
+
+  // ── LEVEL_PERMS constant ───────────────────────────────────────────────────
+
+  describe('LEVEL_PERMS', () => {
+    it('view maps to [read]', () => {
+      expect(component.LEVEL_PERMS['view']).toEqual(['read'])
+    })
+
+    it('update maps to [read, write]', () => {
+      expect(component.LEVEL_PERMS['update']).toEqual(['read', 'write'])
+    })
+
+    it('admin maps to all four perms', () => {
+      expect(component.LEVEL_PERMS['admin']).toEqual(['read', 'write', 'admin', 'delete'])
     })
   })
 })

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -435,6 +435,42 @@ describe('PermissionManagerComponent', () => {
       component.grantBulk()
       expect(permsSvc.grantPerm).not.toHaveBeenCalled()
     })
+
+    it('revokes permissions above the requested level (downgrade support)', () => {
+      component.records = [{ id: 'mdm:001', apiBase: 'https://api/' }]
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.bulkLevel = 'view'  // grant view: only read should remain
+
+      component.grantBulk()
+
+      // must grant read
+      expect(permsSvc.grantPerm).toHaveBeenCalledWith(
+        expect.any(Object), 'read', 'alice'
+      )
+      // must revoke write, admin, delete
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(
+        expect.any(Object), 'write', 'alice'
+      )
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(
+        expect.any(Object), 'admin', 'alice'
+      )
+      expect(permsSvc.revokePerm).toHaveBeenCalledWith(
+        expect.any(Object), 'delete', 'alice'
+      )
+    })
+
+    it('does NOT revoke permissions that are part of the requested level', () => {
+      component.records = [{ id: 'mdm:001', apiBase: 'https://api/' }]
+      component.staged.set([{ id: 'alice', label: 'Alice' }])
+      component.bulkLevel = 'update'  // read + write — must not revoke read or write
+
+      component.grantBulk()
+
+      const revokeCalls = (permsSvc.revokePerm as jest.Mock).mock.calls
+      const revokedPerms = revokeCalls.map((c: any[]) => c[1])
+      expect(revokedPerms).not.toContain('read')
+      expect(revokedPerms).not.toContain('write')
+    })
   })
 
   // ── loadAcls() ─────────────────────────────────────────────────────────────

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -221,14 +221,13 @@ describe('PermissionManagerComponent', () => {
       permsSvc.revokePerm.mockReturnValue(throwError(() => new Error('403')))
       permsSvc.grantPerm.mockReturnValue(of(['alice']))
 
-      // alice has read + write but NOT admin/delete — upgrading to admin triggers grants
-      component.acls.set(makeAcls(['alice'], ['alice'], [], []))
-      // mock getAcls for loadAcls()
-      permsSvc.getAcls.mockReturnValue(of({ read: ['alice'], write: ['alice'], admin: ['alice'], delete: ['alice'] }))
+      // alice at full admin — downgrading to view produces toRevoke=[write,admin,delete]
+      // which calls revokePerm 3 times; revokePerm throws, hitting the error path
+      component.acls.set(makeAcls(['alice'], ['alice'], ['alice'], ['alice']))
+      permsSvc.getAcls.mockReturnValue(of(makeAcls(['alice'], [], [], [])))
 
-      component.setSubjectLevel('alice', 'admin')
+      component.setSubjectLevel('alice', 'view')
 
-      // forkJoin error path — loadAcls must be called
       expect(permsSvc.getAcls).toHaveBeenCalled()
     })
   })

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -163,6 +163,10 @@ describe('PermissionManagerComponent', () => {
       expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'admin', 'alice')
       expect(permsSvc.grantPerm).toHaveBeenCalledWith(RECORD, 'delete', 'alice')
       expect(permsSvc.revokePerm).not.toHaveBeenCalled()
+      // The key invariant: read is already held — grantPerm must NOT be called for 'read'
+      expect(permsSvc.grantPerm).not.toHaveBeenCalledWith(
+        expect.any(Object), 'read', 'alice'
+      )
     })
 
     it('revokes excess perms when downgrading to view', () => {
@@ -384,7 +388,7 @@ describe('PermissionManagerComponent', () => {
 
   describe('grantBulk()', () => {
     beforeEach(() => {
-      component.records = [RECORD]
+      fixture.componentRef.setInput('records', [RECORD])
       component.staged.set([{ id: 'alice', label: 'Alice' }])
       component.bulkLevel = 'update'
     })
@@ -431,13 +435,13 @@ describe('PermissionManagerComponent', () => {
     })
 
     it('is a no-op when records is empty', () => {
-      component.records = []
+      fixture.componentRef.setInput('records', [])
       component.grantBulk()
       expect(permsSvc.grantPerm).not.toHaveBeenCalled()
     })
 
     it('revokes permissions above the requested level (downgrade support)', () => {
-      component.records = [{ id: 'mdm:001', apiBase: 'https://api/' }]
+      fixture.componentRef.setInput('records', [{ id: 'mdm:001', apiBase: 'https://api/' }])
       component.staged.set([{ id: 'alice', label: 'Alice' }])
       component.bulkLevel = 'view'  // grant view: only read should remain
 
@@ -460,7 +464,7 @@ describe('PermissionManagerComponent', () => {
     })
 
     it('does NOT revoke permissions that are part of the requested level', () => {
-      component.records = [{ id: 'mdm:001', apiBase: 'https://api/' }]
+      fixture.componentRef.setInput('records', [{ id: 'mdm:001', apiBase: 'https://api/' }])
       component.staged.set([{ id: 'alice', label: 'Alice' }])
       component.bulkLevel = 'update'  // read + write — must not revoke read or write
 
@@ -612,6 +616,140 @@ describe('PermissionManagerComponent', () => {
       component.showNewGroupForm.set(true)
       component.cancelCreate()
       expect(component.showNewGroupForm()).toBe(false)
+    })
+  })
+
+  // ── createGroup() ─────────────────────────────────────────────────────────
+
+  describe('createGroup()', () => {
+    it('calls groupsSvc.createGroup with trimmed name', () => {
+      component.newGroupName = '  My Team  '
+      component.createGroup()
+      expect(groupsSvc.createGroup).toHaveBeenCalledWith('My Team')
+    })
+
+    it('does nothing when name is blank', () => {
+      component.newGroupName = '   '
+      component.createGroup()
+      expect(groupsSvc.createGroup).not.toHaveBeenCalled()
+    })
+
+    it('appends the new group to the groups signal', () => {
+      groupsSvc.createGroup.mockReturnValue(
+        of({ id: 'grp0:alice:newteam', name: 'New Team', owner: 'alice', members: [] })
+      )
+      component.newGroupName = 'New Team'
+      component.groups.set([])
+      component.createGroup()
+      expect(component.groups()).toHaveLength(1)
+      expect(component.groups()[0].id).toBe('grp0:alice:newteam')
+    })
+
+    it('resets newGroupName and hides the form on success', () => {
+      groupsSvc.createGroup.mockReturnValue(
+        of({ id: 'grp0:alice:newteam', name: 'New Team', owner: 'alice', members: [] })
+      )
+      component.newGroupName = 'New Team'
+      component.showNewGroupForm.set(true)
+      component.createGroup()
+      expect(component.newGroupName).toBe('')
+      expect(component.showNewGroupForm()).toBe(false)
+    })
+
+    it('logs error on failure', () => {
+      groupsSvc.createGroup.mockReturnValue(throwError(() => new Error('500')))
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      component.newGroupName = 'Bad Team'
+      component.createGroup()
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+  })
+
+  // ── deleteGroup() ─────────────────────────────────────────────────────────
+
+  describe('deleteGroup()', () => {
+    it('removes the group from the groups signal', () => {
+      groupsSvc.deleteGroup.mockReturnValue(of('deleted'))
+      component.groups.set([
+        { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] },
+        { id: 'grp0:alice:other', name: 'Other', owner: 'alice', members: [] },
+      ])
+      component.deleteGroup('grp0:alice:team')
+      expect(component.groups()).toHaveLength(1)
+      expect(component.groups()[0].id).toBe('grp0:alice:other')
+    })
+
+    it('resets expandedGroupId when the deleted group was expanded', () => {
+      groupsSvc.deleteGroup.mockReturnValue(of('deleted'))
+      component.groups.set([{ id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] }])
+      component.expandedGroupId.set('grp0:alice:team')
+      component.deleteGroup('grp0:alice:team')
+      expect(component.expandedGroupId()).toBeNull()
+    })
+
+    it('does not reset expandedGroupId when a different group is deleted', () => {
+      groupsSvc.deleteGroup.mockReturnValue(of('deleted'))
+      component.groups.set([
+        { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: [] },
+        { id: 'grp0:alice:other', name: 'Other', owner: 'alice', members: [] },
+      ])
+      component.expandedGroupId.set('grp0:alice:team')
+      component.deleteGroup('grp0:alice:other')
+      expect(component.expandedGroupId()).toBe('grp0:alice:team')
+    })
+  })
+
+  // ── removeGroupMember() ────────────────────────────────────────────────────
+
+  describe('removeGroupMember()', () => {
+    it('removes the member from the group in the groups signal', () => {
+      groupsSvc.removeMember.mockReturnValue(of('removed'))
+      component.groups.set([{
+        id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: ['alice', 'bob']
+      }])
+      component.removeGroupMember('grp0:alice:team', 'bob')
+      expect(component.groups()[0].members).toEqual(['alice'])
+      expect(component.groups()[0].members).not.toContain('bob')
+    })
+
+    it('does not modify other groups', () => {
+      groupsSvc.removeMember.mockReturnValue(of('removed'))
+      component.groups.set([
+        { id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: ['bob'] },
+        { id: 'grp0:alice:other', name: 'Other', owner: 'alice', members: ['bob'] },
+      ])
+      component.removeGroupMember('grp0:alice:team', 'bob')
+      expect(component.groups()[1].members).toContain('bob')
+    })
+  })
+
+  // ── addGroupMember() ───────────────────────────────────────────────────────
+
+  describe('addGroupMember()', () => {
+    beforeEach(() => {
+      component.groups.set([{
+        id: 'grp0:alice:team', name: 'Team', owner: 'alice', members: []
+      }])
+      // memberPeopleIndex is a private field; set it via the member search response path
+      ;(component as any).memberPeopleIndex = { 'Bob Smith': 'bob' }
+    })
+
+    it('calls groupsSvc.addMember with the resolved EID', () => {
+      groupsSvc.addMember.mockReturnValue(of(['bob']))
+      component.addGroupMember('grp0:alice:team', 'Bob Smith')
+      expect(groupsSvc.addMember).toHaveBeenCalledWith('grp0:alice:team', 'bob')
+    })
+
+    it('updates the group members signal on success', () => {
+      groupsSvc.addMember.mockReturnValue(of(['bob', 'carol']))
+      component.addGroupMember('grp0:alice:team', 'Bob Smith')
+      expect(component.groups()[0].members).toEqual(['bob', 'carol'])
+    })
+
+    it('does nothing when the label has no matching EID in memberPeopleIndex', () => {
+      component.addGroupMember('grp0:alice:team', 'Unknown Person')
+      expect(groupsSvc.addMember).not.toHaveBeenCalled()
     })
   })
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -494,12 +494,12 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       .filter(p => (current[p] ?? []).includes(subject))
     if (!toRevoke.length) return
 
-    let remaining = toRevoke.length
-    toRevoke.forEach(p => {
-      this.permsSvc.revokePerm(record, p, subject).subscribe({
-        next: () => { if (--remaining === 0) { this.loadAcls(); this.permissionsChanged.emit() } },
-        error: err => console.error('[PermissionManager] removeSubject error:', err)
-      })
+    forkJoin(toRevoke.map(p => this.permsSvc.revokePerm(record, p, subject))).subscribe({
+      next: () => { this.loadAcls(); this.permissionsChanged.emit() },
+      error: (err: unknown) => {
+        this.loadAcls()
+        console.error('[PermissionManager] removeSubject error:', err)
+      }
     })
   }
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, inject, signal, computed } from '@angular/core'
-import { Subject, Subscription, of } from 'rxjs'
+import { Subject, Subscription, Observable, of } from 'rxjs'
 import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators'
 import { HttpClient } from '@angular/common/http'
 import { MatDialog } from '@angular/material/dialog'
@@ -456,7 +456,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     return null
   }
 
-  setSubjectLevel(subject: string, newLevel: 'view' | 'update' | 'admin'): void {
+  setSubjectLevel(subject: string, newLevel: 'view' | 'update' | 'admin', emitChange = true): void {
     const record = this.singleRecord()
     if (!record) return
     const current = this.acls()
@@ -466,16 +466,22 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const all: AclPerm[] = ['read', 'write', 'admin', 'delete']
     const toGrant = required.filter(p => !(current[p] ?? []).includes(subject))
     const toRevoke = all.filter(p => !required.includes(p) && (current[p] ?? []).includes(subject))
-    const grantOps = toGrant.map(p => this.permsSvc.grantPerm(record, p, subject))
-    const revokeOps = toRevoke.map(p => this.permsSvc.revokePerm(record, p, subject))
-    const total = grantOps.length + revokeOps.length
-    if (!total) return
+    const ops: Observable<unknown>[] = [
+      ...toGrant.map(p => this.permsSvc.grantPerm(record, p, subject)),
+      ...toRevoke.map(p => this.permsSvc.revokePerm(record, p, subject)),
+    ]
+    if (!ops.length) return
 
-    let remaining = total
-    const onNext = () => { if (--remaining === 0) { this.loadAcls(); this.permissionsChanged.emit() } }
-    const onError = (err: unknown) => console.error('[PermissionManager] setSubjectLevel error:', err)
-    grantOps.forEach(op$ => op$.subscribe({ next: onNext, error: onError }))
-    revokeOps.forEach(op$ => op$.subscribe({ next: onNext, error: onError }))
+    let remaining = ops.length
+    ops.forEach(op$ => op$.subscribe({
+      next: () => {
+        if (--remaining === 0) {
+          this.loadAcls()
+          if (emitChange) this.permissionsChanged.emit()
+        }
+      },
+      error: (err: unknown) => console.error('[PermissionManager] setSubjectLevel error:', err)
+    }))
   }
 
   removeSubject(subject: string): void {
@@ -503,7 +509,35 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const people = this.staged()
     if (!people.length) return
 
-    people.forEach(person => this.setSubjectLevel(person.id, level))
+    const total = people.length
+    let completed = 0
+
+    const onOneDone = () => {
+      completed++
+      if (completed === total) {
+        this.permissionsChanged.emit()
+      }
+    }
+
+    people.forEach(person => {
+      const currentAcls = this.acls()
+      if (!currentAcls) { onOneDone(); return }
+      const required = this.LEVEL_PERMS[level]
+      const all: AclPerm[] = ['read', 'write', 'admin', 'delete']
+      const toGrant = required.filter(p => !(currentAcls[p] ?? []).includes(person.id))
+      const toRevoke = all.filter(p => !required.includes(p) && (currentAcls[p] ?? []).includes(person.id))
+      const ops: Observable<unknown>[] = [
+        ...toGrant.map(p => this.permsSvc.grantPerm(record, p, person.id)),
+        ...toRevoke.map(p => this.permsSvc.revokePerm(record, p, person.id)),
+      ]
+      if (!ops.length) { onOneDone(); return }
+      let remaining = ops.length
+      ops.forEach(op$ => op$.subscribe({
+        next: () => { if (--remaining === 0) { this.loadAcls(); onOneDone() } },
+        error: (err: unknown) => console.error('[PermissionManager] grantStagedLevel error:', err)
+      }))
+    })
+
     this.closeAddPerson()
   }
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, inject, signal, computed } from '@angular/core'
-import { Subject, Subscription, Observable, of } from 'rxjs'
+import { Subject, Subscription, Observable, of, forkJoin } from 'rxjs'
 import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators'
 import { HttpClient } from '@angular/common/http'
 import { MatDialog } from '@angular/material/dialog'
@@ -472,16 +472,16 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     ]
     if (!ops.length) return
 
-    let remaining = ops.length
-    ops.forEach(op$ => op$.subscribe({
+    forkJoin(ops).subscribe({
       next: () => {
-        if (--remaining === 0) {
-          this.loadAcls()
-          if (emitChange) this.permissionsChanged.emit()
-        }
+        this.loadAcls()
+        if (emitChange) this.permissionsChanged.emit()
       },
-      error: (err: unknown) => console.error('[PermissionManager] setSubjectLevel error:', err)
-    }))
+      error: (err: unknown) => {
+        this.loadAcls()
+        console.error('[PermissionManager] setSubjectLevel error:', err)
+      }
+    })
   }
 
   removeSubject(subject: string): void {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,45 +1,74 @@
-import { Component, Input, signal } from '@angular/core'
-import { AclPerm, RecordRef } from '../group.types'
-
-interface MockGroup {
-  id: string
-  name: string
-  members: string[]
-}
+import { Component, Input, OnChanges, SimpleChanges, inject, signal, computed } from '@angular/core'
+import { GroupsService } from '../groups.service'
+import { PermissionsService } from '../permissions.service'
+import { Group, RecordRef, Acls, AclPerm } from '../group.types'
 
 @Component({
   selector: 'oarng-permission-manager',
   templateUrl: './permission-manager.component.html',
   styleUrl: './permission-manager.component.scss'
 })
-export class PermissionManagerComponent {
+export class PermissionManagerComponent implements OnChanges {
   @Input() records: RecordRef[] = []
   @Input() layout: 'compact' | 'panel' = 'compact'
 
+  private groupsSvc = inject(GroupsService)
+  private permsSvc = inject(PermissionsService)
+
   readonly perms: AclPerm[] = ['read', 'write', 'admin', 'delete']
 
-  // --- My Groups state (stub — no HTTP) ---
+  // ── Groups state ──────────────────────────────────────────────────────────
+  groups = signal<Group[]>([])
+  groupsLoading = signal(false)
+  groupsError = signal<string | null>(null)
 
-  readonly groups = signal<MockGroup[]>([
-    { id: 'grp0:me:lab-team', name: 'lab-team', members: ['alice', 'bob', 'carol'] },
-    { id: 'grp0:me:collaborators', name: 'collaborators', members: ['dave', 'eve'] },
-  ])
-
-  readonly expandedGroupId = signal<string | null>(null)
-  readonly showNewGroupForm = signal(false)
+  expandedGroupId = signal<string | null>(null)
+  showNewGroupForm = signal(false)
   newGroupName = ''
 
-  toggleGroup(id: string): void {
-    this.expandedGroupId.update(current => current === id ? null : id)
+  // ── ACL state ─────────────────────────────────────────────────────────────
+  acls = signal<Acls | null>(null)
+  aclsLoading = signal(false)
+  aclsError = signal<string | null>(null)
+
+  readonly singleRecord = computed(() => this.records.length === 1 ? this.records[0] : null)
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['records']) {
+      this.loadGroups()
+      this.loadAcls()
+    }
+  }
+
+  // ── Groups CRUD ───────────────────────────────────────────────────────────
+
+  loadGroups(): void {
+    this.groupsLoading.set(true)
+    this.groupsError.set(null)
+    this.groupsSvc.getGroups().subscribe({
+      next: groups => {
+        this.groups.set(groups)
+        this.groupsLoading.set(false)
+      },
+      error: err => {
+        this.groupsError.set('Could not load groups.')
+        this.groupsLoading.set(false)
+        console.error('[PermissionManager] loadGroups error:', err)
+      }
+    })
   }
 
   createGroup(): void {
     const name = this.newGroupName.trim()
     if (!name) return
-    const id = `grp0:me:${name}`
-    this.groups.update(gs => [...gs, { id, name, members: [] }])
-    this.newGroupName = ''
-    this.showNewGroupForm.set(false)
+    this.groupsSvc.createGroup(name).subscribe({
+      next: group => {
+        this.groups.update(gs => [...gs, group])
+        this.newGroupName = ''
+        this.showNewGroupForm.set(false)
+      },
+      error: err => console.error('[PermissionManager] createGroup error:', err)
+    })
   }
 
   cancelCreate(): void {
@@ -47,19 +76,62 @@ export class PermissionManagerComponent {
     this.showNewGroupForm.set(false)
   }
 
-  removeGroupMember(groupId: string, member: string): void {
-    this.groups.update(gs =>
-      gs.map(g => g.id === groupId
-        ? { ...g, members: g.members.filter(m => m !== member) }
-        : g
-      )
-    )
+  deleteGroup(groupId: string): void {
+    this.groupsSvc.deleteGroup(groupId).subscribe({
+      next: () => {
+        this.groups.update(gs => gs.filter(g => g.id !== groupId))
+        if (this.expandedGroupId() === groupId) this.expandedGroupId.set(null)
+      },
+      error: err => console.error('[PermissionManager] deleteGroup error:', err)
+    })
   }
 
-  deleteGroup(groupId: string): void {
-    this.groups.update(gs => gs.filter(g => g.id !== groupId))
-    if (this.expandedGroupId() === groupId) {
-      this.expandedGroupId.set(null)
-    }
+  removeGroupMember(groupId: string, memberId: string): void {
+    this.groupsSvc.removeMember(groupId, memberId).subscribe({
+      next: () => {
+        this.groups.update(gs => gs.map(g =>
+          g.id === groupId ? { ...g, members: g.members.filter(m => m !== memberId) } : g
+        ))
+      },
+      error: err => console.error('[PermissionManager] removeMember error:', err)
+    })
+  }
+
+  toggleGroup(id: string): void {
+    this.expandedGroupId.update(cur => cur === id ? null : id)
+  }
+
+  // ── ACL ───────────────────────────────────────────────────────────────────
+
+  loadAcls(): void {
+    const record = this.singleRecord()
+    if (!record) { this.acls.set(null); return }
+
+    this.aclsLoading.set(true)
+    this.aclsError.set(null)
+    this.permsSvc.getAcls(record).subscribe({
+      next: acls => {
+        this.acls.set(acls)
+        this.aclsLoading.set(false)
+      },
+      error: err => {
+        this.aclsError.set('Could not load permissions.')
+        this.aclsLoading.set(false)
+        console.error('[PermissionManager] loadAcls error:', err)
+      }
+    })
+  }
+
+  subjectsFor(perm: AclPerm): string[] {
+    return this.acls()?.[perm] ?? []
+  }
+
+  revokePermission(perm: AclPerm, subject: string): void {
+    const record = this.singleRecord()
+    if (!record) return
+    this.permsSvc.revokePerm(record, perm, subject).subscribe({
+      next: updated => this.acls.set(updated),
+      error: err => console.error('[PermissionManager] revokePerm error:', err)
+    })
   }
 }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -819,8 +819,8 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       this.peopleSuggestions.set([])
     })
 
-    const personUrl = (this.configSvc.getConfig<any>()['personURL'] ?? '') as string
-    if (personUrl) {
+    const personUrl = ((this.configSvc.getConfig<any>()['personURL'] ?? '') as string).replace(/\/?$/, '/')
+    if (personUrl !== '/') {
       this.http.get<any>(`${personUrl}${peopleId}`).subscribe({
         next: person => {
           const subject = person?.nistUsername || peopleId

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -509,36 +509,36 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const people = this.staged()
     if (!people.length) return
 
-    const total = people.length
-    let completed = 0
-
-    const onOneDone = () => {
-      completed++
-      if (completed === total) {
-        this.permissionsChanged.emit()
-      }
-    }
-
-    people.forEach(person => {
-      const currentAcls = this.acls()
-      if (!currentAcls) { onOneDone(); return }
+    const currentAcls = this.acls()
+    const allOps: Observable<unknown>[] = people.flatMap(person => {
+      if (!currentAcls) return []
       const required = this.LEVEL_PERMS[level]
       const all: AclPerm[] = ['read', 'write', 'admin', 'delete']
       const toGrant = required.filter(p => !(currentAcls[p] ?? []).includes(person.id))
       const toRevoke = all.filter(p => !required.includes(p) && (currentAcls[p] ?? []).includes(person.id))
-      const ops: Observable<unknown>[] = [
+      return [
         ...toGrant.map(p => this.permsSvc.grantPerm(record, p, person.id)),
         ...toRevoke.map(p => this.permsSvc.revokePerm(record, p, person.id)),
       ]
-      if (!ops.length) { onOneDone(); return }
-      let remaining = ops.length
-      ops.forEach(op$ => op$.subscribe({
-        next: () => { if (--remaining === 0) { this.loadAcls(); onOneDone() } },
-        error: (err: unknown) => console.error('[PermissionManager] grantStagedLevel error:', err)
-      }))
     })
 
     this.closeAddPerson()
+
+    if (!allOps.length) {
+      this.permissionsChanged.emit()
+      return
+    }
+
+    forkJoin(allOps).subscribe({
+      next: () => {
+        this.loadAcls()
+        this.permissionsChanged.emit()
+      },
+      error: (err: unknown) => {
+        this.loadAcls()
+        console.error('[PermissionManager] grantStagedLevel error:', err)
+      }
+    })
   }
 
   // ── Confirmation wrappers ─────────────────────────────────────────────────

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -596,6 +596,20 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     }, () => this.setSubjectLevel(subject, newLevel))
   }
 
+  changeLevel(subject: string, fromLevel: string, toLevel: 'view' | 'update' | 'admin'): void {
+    this.setSubjectLevel(subject, toLevel)
+  }
+
+  confirmChangeLevel(subject: string, fromLevel: string, toLevel: 'view' | 'update' | 'admin'): void {
+    const label = this.subjectLabels()[subject] || subject
+    const record = this.singleRecord()
+    this.confirm({
+      title: 'Change access level',
+      body: `Change access for "${label}" on ${record?.id} from ${fromLevel} to ${toLevel}?`,
+      confirmLabel: 'Change',
+    }, () => this.changeLevel(subject, fromLevel, toLevel))
+  }
+
   confirmGrantLevel(level: 'view' | 'update' | 'admin'): void {
     const record = this.singleRecord()
     this.confirm({

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,5 +1,11 @@
-import { Component, Input } from '@angular/core'
+import { Component, Input, signal } from '@angular/core'
 import { AclPerm, RecordRef } from '../group.types'
+
+interface MockGroup {
+  id: string
+  name: string
+  members: string[]
+}
 
 @Component({
   selector: 'oarng-permission-manager',
@@ -11,4 +17,49 @@ export class PermissionManagerComponent {
   @Input() layout: 'compact' | 'panel' = 'compact'
 
   readonly perms: AclPerm[] = ['read', 'write', 'admin', 'delete']
+
+  // --- My Groups state (stub — no HTTP) ---
+
+  readonly groups = signal<MockGroup[]>([
+    { id: 'grp0:me:lab-team', name: 'lab-team', members: ['alice', 'bob', 'carol'] },
+    { id: 'grp0:me:collaborators', name: 'collaborators', members: ['dave', 'eve'] },
+  ])
+
+  readonly expandedGroupId = signal<string | null>(null)
+  readonly showNewGroupForm = signal(false)
+  newGroupName = ''
+
+  toggleGroup(id: string): void {
+    this.expandedGroupId.update(current => current === id ? null : id)
+  }
+
+  createGroup(): void {
+    const name = this.newGroupName.trim()
+    if (!name) return
+    const id = `grp0:me:${name}`
+    this.groups.update(gs => [...gs, { id, name, members: [] }])
+    this.newGroupName = ''
+    this.showNewGroupForm.set(false)
+  }
+
+  cancelCreate(): void {
+    this.newGroupName = ''
+    this.showNewGroupForm.set(false)
+  }
+
+  removeGroupMember(groupId: string, member: string): void {
+    this.groups.update(gs =>
+      gs.map(g => g.id === groupId
+        ? { ...g, members: g.members.filter(m => m !== member) }
+        : g
+      )
+    )
+  }
+
+  deleteGroup(groupId: string): void {
+    this.groups.update(gs => gs.filter(g => g.id !== groupId))
+    if (this.expandedGroupId() === groupId) {
+      this.expandedGroupId.set(null)
+    }
+  }
 }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -41,11 +41,11 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     admin:  ['read', 'write', 'admin', 'delete'],
   }
 
-  private readonly NIST_ORG_PREFIX: Record<string, string> = {
-    ou: 'nistou',
-    div: 'nistdiv',
-    grp: 'nistgrp',
-  }
+  private readonly NIST_ORG_TYPES = [
+    { endpoint: 'OU',    prefix: 'nistou'  as const },
+    { endpoint: 'Div',   prefix: 'nistdiv' as const },
+    { endpoint: 'Group', prefix: 'nistgrp' as const },
+  ]
 
   // ── Groups state ──────────────────────────────────────────────────────────
   groups = signal<Group[]>([])
@@ -89,7 +89,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
   })
 
   // ── User's NIST org units ─────────────────────────────────────────────────
-  nistOrgs = signal<{ id: string; name: string }[]>([])
+  nistOrgs = signal<{ id: string; name: string; code: string; type: 'nistou' | 'nistdiv' | 'nistgrp' }[]>([])
   nistOrgsLoading = signal(false)
 
   // ── People picker state ────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
 
   // ── Group search state ────────────────────────────────────────────────────
   groupQuery = ''
-  groupSuggestions = signal<{ id: string; name: string; type: 'midas' | 'nist' }[]>([])
+  groupSuggestions = signal<{ id: string; name: string; code: string; type: 'midas' | 'nistou' | 'nistdiv' | 'nistgrp' }[]>([])
 
   // ── Group member search state ─────────────────────────────────────────────
   memberQuery = ''
@@ -170,28 +170,18 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
         const midas = this.groups()
           .filter(g => wordPrefixMatch(g.name) || g.id.toLowerCase().startsWith(q))
           .slice(0, 5)
-          .map(g => ({ id: g.id, name: g.name, type: 'midas' as const }))
-        const orgUrl = (this.configSvc.getConfig<any>()['orgURL'] ?? '') as string
-        if (!orgUrl) return of(midas)
-        return this.http.get<any>(`${orgUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
-          map(raw => {
-            const nist: { id: string; name: string; type: 'nist' }[] = []
-            if (raw && typeof raw === 'object') {
-              Object.keys(raw).forEach(key => {
-                const group = raw[key]
-                if (group && typeof group === 'object') {
-                  Object.keys(group).forEach(numericId => {
-                    if (key.toLowerCase().startsWith(q) || wordPrefixMatch(group[numericId])) {
-                      const prefix = this.NIST_ORG_PREFIX[key] ?? key
-                      nist.push({ id: `${prefix}:${numericId}`, name: group[numericId], type: 'nist' })
-                    }
-                  })
-                }
-              })
-            }
-            return ([...midas, ...nist] as { id: string; name: string; type: 'midas' | 'nist' }[]).slice(0, 10)
-          }),
-          catchError(() => of(midas))
+          .map(g => ({ id: g.id, name: g.name, code: '', type: 'midas' as const }))
+        const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
+        if (!orgBaseUrl) return of(midas)
+        return forkJoin(
+          this.NIST_ORG_TYPES.map(({ endpoint, prefix }) =>
+            this.http.get<any>(`${orgBaseUrl}/${endpoint}/index?${encodeURIComponent(query.toUpperCase())}`).pipe(
+              map(raw => this.parseOrgIndex(raw, prefix).filter(o => wordPrefixMatch(o.name))),
+              catchError(() => of([]))
+            )
+          )
+        ).pipe(
+          map(results => [...midas, ...results.flat()].slice(0, 10))
         )
       })
     ).subscribe(suggestions => this.groupSuggestions.set(suggestions))
@@ -312,6 +302,12 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     })
   }
 
+  private readonly ORG_TYPE_MAP: Record<string, { endpoint: string; label: string; prefix: 'nistou' | 'nistdiv' | 'nistgrp' }> = {
+    nistou:  { endpoint: 'OU',    label: 'OU',  prefix: 'nistou'  },
+    nistdiv: { endpoint: 'Div',   label: 'Div', prefix: 'nistdiv' },
+    nistgrp: { endpoint: 'Group', label: 'Grp', prefix: 'nistgrp' },
+  }
+
   private resolveUnknownLabels(acls: Acls): void {
     const known = this.subjectLabels()
     const allSubjects = new Set([
@@ -322,12 +318,15 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     ])
     const syncUpdates: { [subject: string]: string } = {}
     const toResolveViaSearch: string[] = []
+    const toResolveViaOrg: string[] = []
 
     for (const subject of allSubjects) {
       if (known[subject]) continue
       const group = this.groups().find(g => g.id === subject)
       if (group) {
         syncUpdates[subject] = group.name
+      } else if (/^nist(ou|div|grp):/.test(subject) || /^\d+:\d+$/.test(subject) || /^[a-z]+:\d+$/.test(subject)) {
+        toResolveViaOrg.push(subject)
       } else if (/^\d+$/.test(subject)) {
         syncUpdates[subject] = `Org group (${subject})`
       } else {
@@ -355,6 +354,78 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
             }
           }
         })
+      })
+    }
+
+    // NIST org subjects — two formats:
+    //   new: "nistou:13289" / "nistdiv:13289" / "nistgrp:13289"
+    //   legacy: "775:13289" (orgCode:orgId, stored by older versions of this UI)
+    // In both cases, display as "{orgName} ({orgCode})".
+    const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
+    if (orgBaseUrl) {
+      toResolveViaOrg.forEach(subject => {
+        const colonIdx = subject.indexOf(':')
+        const prefix = subject.substring(0, colonIdx)
+        const afterColon = subject.substring(colonIdx + 1)
+
+        if (/^nist(ou|div|grp)$/.test(prefix)) {
+          // New format: query the typed endpoint, look up numericId directly
+          const mapping = this.ORG_TYPE_MAP[prefix]
+          this.http.get<any>(`${orgBaseUrl}/${mapping.endpoint}/index`).pipe(
+            catchError(() => of({}))
+          ).subscribe((raw: any) => {
+            const numericId = afterColon
+            for (const code of Object.keys(raw ?? {})) {
+              const group = raw[code]
+              if (group && typeof group === 'object' && group[numericId]) {
+                const name = (group[numericId] as string).replace(/\s*\(\d+\)\s*$/, '')
+                this.subjectLabels.update(m => ({ ...m, [subject]: `${name} (${code})` }))
+                return
+              }
+            }
+          })
+        } else if (/^\d+$/.test(prefix)) {
+          // Legacy format "775:13289" (orgCode:orgId) — direct lookup by both keys
+          const orgCode = prefix
+          const orgId = afterColon
+          forkJoin(
+            this.NIST_ORG_TYPES.map(({ endpoint }) =>
+              this.http.get<any>(`${orgBaseUrl}/${endpoint}/index`).pipe(
+                catchError(() => of({}))
+              )
+            )
+          ).subscribe(responses => {
+            for (const raw of responses) {
+              const group = raw?.[orgCode]
+              if (group && typeof group === 'object' && group[orgId]) {
+                const name = (group[orgId] as string).replace(/\s*\(\d+\)\s*$/, '')
+                this.subjectLabels.update(m => ({ ...m, [subject]: `${name} (${orgCode})` }))
+                return
+              }
+            }
+          })
+        } else {
+          // Org abbreviation format "mml:13213" — scan all endpoints by orgId, get code from outer key
+          const orgId = afterColon
+          forkJoin(
+            this.NIST_ORG_TYPES.map(({ endpoint }) =>
+              this.http.get<any>(`${orgBaseUrl}/${endpoint}/index`).pipe(
+                catchError(() => of({}))
+              )
+            )
+          ).subscribe(responses => {
+            for (const raw of responses) {
+              for (const code of Object.keys(raw ?? {})) {
+                const group = raw[code]
+                if (group && typeof group === 'object' && group[orgId]) {
+                  const name = (group[orgId] as string).replace(/\s*\(\d+\)\s*$/, '')
+                  this.subjectLabels.update(m => ({ ...m, [subject]: `${name} (${code})` }))
+                  return
+                }
+              }
+            }
+          })
+        }
       })
     }
   }
@@ -634,13 +705,16 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
 
   confirmDeleteGroup(groupId: string): void {
     const group = this.groups().find(g => g.id === groupId)
-    const count = group?.members.length ?? 0
+    const members = group?.members ?? []
+    const labels = this.subjectLabels()
     this.confirm({
       title: 'Delete group',
       body: `Permanently delete group "${group?.name}"?`,
-      items: count > 0
-        ? [`${count} member${count > 1 ? 's' : ''} will lose access granted through this group`]
+      items: members.length > 0
+        ? [`${members.length} member${members.length !== 1 ? 's' : ''} will lose access granted through this group`]
         : ['This group has no members'],
+      section: members.length > 0 ? 'Members' : undefined,
+      sectionItems: members.length > 0 ? members.map(m => labels[m] ?? m) : undefined,
       confirmLabel: 'Delete',
       isDestructive: true,
     }, () => this.deleteGroup(groupId))
@@ -649,29 +723,23 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
   // ── User's NIST org units ─────────────────────────────────────────────────
 
   loadNistOrgs(ou: string): void {
-    const orgUrl = (this.configSvc.getConfig<any>()['orgURL'] ?? '') as string
-    if (!orgUrl || !ou) return
+    const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
+    if (!orgBaseUrl || !ou) return
     this.nistOrgsLoading.set(true)
-    this.http.get<any>(`${orgUrl}?${encodeURIComponent(ou.toUpperCase())}`).subscribe({
-      next: raw => {
-        const flat: { id: string; name: string; key: string }[] = []
-        if (raw && typeof raw === 'object') {
-          Object.keys(raw).forEach(key => {
-            const group = raw[key]
-            if (group && typeof group === 'object') {
-              Object.keys(group).forEach(numericId => {
-                const prefix = this.NIST_ORG_PREFIX[key] ?? key
-                flat.push({ id: `${prefix}:${numericId}`, name: group[numericId], key })
-              })
-            }
-          })
-        }
+    forkJoin(
+      this.NIST_ORG_TYPES.map(({ endpoint, prefix }) =>
+        this.http.get<any>(`${orgBaseUrl}/${endpoint}/index?${encodeURIComponent(ou.toUpperCase())}`).pipe(
+          map(raw => this.parseOrgIndex(raw, prefix)),
+          catchError(() => of([]))
+        )
+      )
+    ).subscribe({
+      next: results => {
         const q = ou.toLowerCase()
         const seen = new Set<string>()
-        const orgs = flat
-          .filter(o => o.name.toLowerCase().includes(q) || o.key.toLowerCase().includes(q))
+        const orgs = results.flat()
+          .filter(o => o.name.toLowerCase().includes(q))
           .filter(o => !seen.has(o.id) && seen.add(o.id))
-          .map(o => ({ id: o.id, name: o.name }))
         this.nistOrgs.set(orgs)
         this.nistOrgsLoading.set(false)
       },
@@ -679,12 +747,40 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     })
   }
 
-  stageNistOrg(org: { id: string; name: string }): void {
+  private parseOrgIndex(
+    raw: any,
+    prefix: 'nistou' | 'nistdiv' | 'nistgrp'
+  ): { id: string; name: string; code: string; type: 'nistou' | 'nistdiv' | 'nistgrp' }[] {
+    const out: { id: string; name: string; code: string; type: 'nistou' | 'nistdiv' | 'nistgrp' }[] = []
+    if (!raw || typeof raw !== 'object') return out
+    Object.keys(raw).forEach(code => {
+      const group = raw[code]
+      if (group && typeof group === 'object') {
+        Object.keys(group).forEach(numericId => {
+          out.push({ id: `${prefix}:${numericId}`, name: group[numericId], code, type: prefix })
+        })
+      }
+    })
+    return out
+  }
+
+  stageNistOrg(org: { id: string; name: string; code: string; type: 'nistou' | 'nistdiv' | 'nistgrp' }): void {
     this._addStaged(org.id, org.name)
+    this.subjectLabels.update(m => ({
+      ...m,
+      [org.id]: `${org.name} (${org.code})`
+    }))
   }
 
   isNistOrgStaged(orgId: string): boolean {
     return this.staged().some(s => s.id === orgId)
+  }
+
+  orgTypeLabel(type: string): string {
+    if (type === 'nistou')  return 'OU'
+    if (type === 'nistdiv') return 'Div'
+    if (type === 'nistgrp') return 'Grp'
+    return ''
   }
 
   // ── People picker ─────────────────────────────────────────────────────────

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core'
+import { AclPerm } from '../group.types'
+
+@Component({
+  selector: 'oarng-permission-manager',
+  templateUrl: './permission-manager.component.html',
+  styleUrl: './permission-manager.component.scss'
+})
+export class PermissionManagerComponent {
+  @Input() recordId: string = ''
+  @Input() apiBase: string = ''
+
+  readonly perms: AclPerm[] = ['read', 'write', 'admin', 'delete']
+}

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -74,6 +74,20 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     ]))
   })
 
+  readonly subjectsByLevel = computed(() => {
+    const subjects = this.uniqueSubjects()
+    const admin: string[] = []
+    const update: string[] = []
+    const view: string[] = []
+    for (const s of subjects) {
+      const level = this.subjectLevel(s)
+      if (level === 'admin') admin.push(s)
+      else if (level === 'update') update.push(s)
+      else if (level === 'view') view.push(s)
+    }
+    return { admin, update, view }
+  })
+
   // ── User's NIST org units ─────────────────────────────────────────────────
   nistOrgs = signal<{ id: string; name: string }[]>([])
   nistOrgsLoading = signal(false)
@@ -457,6 +471,14 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     if (r && w) return 'update'
     if (r) return 'view'
     return null
+  }
+
+  isGroup(subject: string): boolean {
+    // Numeric IDs are NIST org groups; prefixed IDs (e.g. nistou:123) are NIST org units;
+    // MIDAS group IDs match an entry in the loaded groups list.
+    if (/^\d+$/.test(subject) || /^nist(ou|div|grp):/.test(subject)) return true
+    if (this.groups().some(g => g.id === subject)) return true
+    return false
   }
 
   setSubjectLevel(subject: string, newLevel: 'view' | 'update' | 'admin', emitChange = true): void {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,21 +1,45 @@
-import { Component, Input, OnChanges, SimpleChanges, inject, signal, computed } from '@angular/core'
+import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, inject, signal, computed } from '@angular/core'
+import { Subject, Subscription, of } from 'rxjs'
+import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators'
+import { HttpClient } from '@angular/common/http'
+import { MatDialog } from '@angular/material/dialog'
 import { GroupsService } from '../groups.service'
 import { PermissionsService } from '../permissions.service'
+import { ConfigurationService } from '../../config/config.service'
 import { Group, RecordRef, Acls, AclPerm } from '../group.types'
+import { ConfirmDialogComponent, ConfirmDialogData } from '../confirm-dialog.component'
+
+interface PersonSuggestion {
+  id: string
+  label: string
+}
 
 @Component({
   selector: 'oarng-permission-manager',
   templateUrl: './permission-manager.component.html',
   styleUrl: './permission-manager.component.scss'
 })
-export class PermissionManagerComponent implements OnChanges {
+export class PermissionManagerComponent implements OnChanges, OnDestroy {
   @Input() records: RecordRef[] = []
   @Input() layout: 'compact' | 'panel' = 'compact'
+  @Input() userOu: string = ''
+  @Input() section: 'permissions' | 'groups' = 'permissions'
+
+  @Output() permissionsChanged = new EventEmitter<void>()
 
   private groupsSvc = inject(GroupsService)
   private permsSvc = inject(PermissionsService)
+  private http = inject(HttpClient)
+  private configSvc = inject(ConfigurationService)
+  private dialog = inject(MatDialog)
 
-  readonly perms: AclPerm[] = ['read', 'write', 'admin', 'delete']
+  // ── Graduated permission model ────────────────────────────────────────────
+
+  readonly LEVEL_PERMS: Record<'view' | 'update' | 'admin', AclPerm[]> = {
+    view:   ['read'],
+    update: ['read', 'write'],
+    admin:  ['read', 'write', 'admin', 'delete'],
+  }
 
   // ── Groups state ──────────────────────────────────────────────────────────
   groups = signal<Group[]>([])
@@ -31,13 +55,223 @@ export class PermissionManagerComponent implements OnChanges {
   aclsLoading = signal(false)
   aclsError = signal<string | null>(null)
 
-  readonly singleRecord = computed(() => this.records.length === 1 ? this.records[0] : null)
+  readonly singleRecord = signal<RecordRef | null>(null)
+
+  readonly uniqueSubjects = computed(() => {
+    const acls = this.acls()
+    if (!acls) return []
+    return Array.from(new Set([
+      ...(acls.read ?? []),
+      ...(acls.write ?? []),
+      ...(acls.admin ?? []),
+      ...(acls.delete ?? []),
+    ]))
+  })
+
+  // ── User's NIST org units ─────────────────────────────────────────────────
+  nistOrgs = signal<{ id: string; name: string }[]>([])
+  nistOrgsLoading = signal(false)
+
+  // ── People picker state ────────────────────────────────────────────────────
+  showAddPanel = signal(false)
+  grantLevelValue: 'view' | 'update' | 'admin' = 'update'
+  peopleQuery = ''
+  peopleSuggestions = signal<string[]>([])
+  staged = signal<PersonSuggestion[]>([])
+  peopleSearchLoading = signal(false)
+  subjectLabels = signal<{ [subject: string]: string }>({})
+
+  // ── Bulk grant state (multiple records) ──────────────────────────────────
+  bulkLevel: 'view' | 'update' | 'admin' = 'update'
+  bulkGranting = signal(false)
+  bulkGrantError = signal<string | null>(null)
+
+  // ── Group search state ────────────────────────────────────────────────────
+  groupQuery = ''
+  groupSuggestions = signal<{ id: string; name: string; type: 'midas' | 'nist' }[]>([])
+
+  // ── Group member search state ─────────────────────────────────────────────
+  memberQuery = ''
+  memberSuggestions = signal<string[]>([])
+  memberSearchLoading = signal(false)
+
+  private peopleIndex: { [label: string]: string } = {}
+  private memberPeopleIndex: { [label: string]: string } = {}
+  private searchInput$ = new Subject<string>()
+  private searchSub!: Subscription
+  private groupSearchInput$ = new Subject<string>()
+  private groupSearchSub!: Subscription
+  private memberSearchInput$ = new Subject<string>()
+  private memberSearchSub!: Subscription
+
+  constructor() {
+    this.searchSub = this.searchInput$.pipe(
+      debounceTime(250),
+      distinctUntilChanged(),
+      switchMap(query => {
+        if (query.length < 2) return of(null)
+        this.peopleSearchLoading.set(true)
+        const baseUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
+        return this.http.get<any>(`${baseUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
+          map(raw => ({ raw, query })),
+          catchError(() => of(null))
+        )
+      })
+    ).subscribe(result => {
+      this.peopleSearchLoading.set(false)
+      if (!result) { this.peopleSuggestions.set([]); return }
+      const { raw, query } = result
+      const all: string[] = []
+      this.peopleIndex = {}
+      Object.keys(raw).forEach(lastName => {
+        const group = raw[lastName]
+        if (group && typeof group === 'object') {
+          Object.keys(group).forEach(id => {
+            const label: string = group[id]
+            all.push(label)
+            this.peopleIndex[label] = id
+          })
+        }
+      })
+      const q = query.toLowerCase()
+      this.peopleSuggestions.set(
+        all.filter(label => label.toLowerCase().includes(q)).slice(0, 10)
+      )
+    })
+
+    this.groupSearchSub = this.groupSearchInput$.pipe(
+      debounceTime(200),
+      distinctUntilChanged(),
+      switchMap(query => {
+        if (query.length < 3) return of([])
+        const q = query.toLowerCase()
+        const wordPrefixMatch = (text: string) =>
+          text.toLowerCase().split(/[\s()]+/).some(word => word.startsWith(q))
+        const midas = this.groups()
+          .filter(g => wordPrefixMatch(g.name) || g.id.toLowerCase().startsWith(q))
+          .slice(0, 5)
+          .map(g => ({ id: g.id, name: g.name, type: 'midas' as const }))
+        const orgUrl = (this.configSvc.getConfig<any>()['orgURL'] ?? '') as string
+        if (!orgUrl) return of(midas)
+        return this.http.get<any>(`${orgUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
+          map(raw => {
+            const nist: { id: string; name: string; type: 'nist' }[] = []
+            if (raw && typeof raw === 'object') {
+              Object.keys(raw).forEach(key => {
+                const group = raw[key]
+                if (group && typeof group === 'object') {
+                  Object.keys(group).forEach(id => {
+                    // key.startsWith(q) handles org codes like MML, ITL; wordPrefixMatch handles names
+                    if (key.toLowerCase().startsWith(q) || wordPrefixMatch(group[id])) {
+                      nist.push({ id, name: group[id], type: 'nist' })
+                    }
+                  })
+                }
+              })
+            }
+            return ([...midas, ...nist] as { id: string; name: string; type: 'midas' | 'nist' }[]).slice(0, 10)
+          }),
+          catchError(() => of(midas))
+        )
+      })
+    ).subscribe(suggestions => this.groupSuggestions.set(suggestions))
+
+    this.memberSearchSub = this.memberSearchInput$.pipe(
+      debounceTime(250),
+      distinctUntilChanged(),
+      switchMap(query => {
+        if (query.length < 2) return of(null)
+        this.memberSearchLoading.set(true)
+        const baseUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
+        return this.http.get<any>(`${baseUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
+          map(raw => ({ raw, query })),
+          catchError(() => of(null))
+        )
+      })
+    ).subscribe(result => {
+      this.memberSearchLoading.set(false)
+      if (!result) { this.memberSuggestions.set([]); return }
+      const { raw, query } = result
+      const all: string[] = []
+      this.memberPeopleIndex = {}
+      Object.keys(raw).forEach(lastName => {
+        const group = raw[lastName]
+        if (group && typeof group === 'object') {
+          Object.keys(group).forEach(id => {
+            const label: string = group[id]
+            all.push(label)
+            this.memberPeopleIndex[label] = id
+          })
+        }
+      })
+      const q = query.toLowerCase()
+      this.memberSuggestions.set(
+        all.filter(label => label.toLowerCase().includes(q)).slice(0, 10)
+      )
+    })
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['records']) {
+      this.singleRecord.set(this.records.length === 1 ? this.records[0] : null)
       this.loadGroups()
       this.loadAcls()
     }
+    if (changes['section'] && this.section === 'groups') {
+      this.loadGroups()
+    }
+    if (changes['userOu'] && this.userOu) {
+      this.loadNistOrgs(this.userOu)
+    }
+  }
+
+  grantBulk(): void {
+    const people = this.staged()
+    const level = this.bulkLevel
+    if (!people.length || !this.records.length) return
+
+    const permsToGrant = this.LEVEL_PERMS[level]
+    this.bulkGranting.set(true)
+    this.bulkGrantError.set(null)
+
+    let remaining = people.length * this.records.length * permsToGrant.length
+    let failed = 0
+
+    people.forEach(person => {
+      this.records.forEach(record => {
+        permsToGrant.forEach(perm => {
+          this.permsSvc.grantPerm(record, perm, person.id).subscribe({
+            next: () => {
+              if (--remaining === 0) {
+                this.bulkGranting.set(false)
+                if (failed === 0) {
+                  this.staged.set([])
+                  this.peopleQuery = ''
+                  this.groupQuery = ''
+                  this.peopleSuggestions.set([])
+                  this.groupSuggestions.set([])
+                  this.permissionsChanged.emit()
+                }
+              }
+            },
+            error: err => {
+              failed++
+              if (--remaining === 0) {
+                this.bulkGranting.set(false)
+                this.bulkGrantError.set(`${failed} operation(s) failed.`)
+              }
+              console.error('[PermissionManager] bulk grant error:', err)
+            }
+          })
+        })
+      })
+    })
+  }
+
+  ngOnDestroy(): void {
+    this.searchSub.unsubscribe()
+    this.groupSearchSub.unsubscribe()
+    this.memberSearchSub.unsubscribe()
   }
 
   // ── Groups CRUD ───────────────────────────────────────────────────────────
@@ -49,6 +283,9 @@ export class PermissionManagerComponent implements OnChanges {
       next: groups => {
         this.groups.set(groups)
         this.groupsLoading.set(false)
+        // Resolve any ACL subjects that are MIDAS group IDs
+        const acls = this.acls()
+        if (acls) this.resolveUnknownLabels(acls)
       },
       error: err => {
         this.groupsError.set('Could not load groups.')
@@ -56,6 +293,53 @@ export class PermissionManagerComponent implements OnChanges {
         console.error('[PermissionManager] loadGroups error:', err)
       }
     })
+  }
+
+  private resolveUnknownLabels(acls: Acls): void {
+    const known = this.subjectLabels()
+    const allSubjects = new Set([
+      ...(acls.read ?? []),
+      ...(acls.write ?? []),
+      ...(acls.admin ?? []),
+      ...(acls.delete ?? []),
+    ])
+    const syncUpdates: { [subject: string]: string } = {}
+    const toResolveViaSearch: string[] = []
+
+    for (const subject of allSubjects) {
+      if (known[subject]) continue
+      const group = this.groups().find(g => g.id === subject)
+      if (group) {
+        syncUpdates[subject] = group.name
+      } else if (/^\d+$/.test(subject)) {
+        syncUpdates[subject] = `Org group (${subject})`
+      } else {
+        toResolveViaSearch.push(subject)
+      }
+    }
+
+    if (Object.keys(syncUpdates).length > 0) {
+      this.subjectLabels.update(m => ({ ...m, ...syncUpdates }))
+    }
+
+    // EIDs: search the people API with the EID as query and look for an exact key match
+    const peopleUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
+    if (peopleUrl) {
+      toResolveViaSearch.forEach(eid => {
+        this.http.get<any>(`${peopleUrl}?${encodeURIComponent(eid.toUpperCase())}`).pipe(
+          catchError(() => of({}))
+        ).subscribe((raw: any) => {
+          if (!raw || typeof raw !== 'object') return
+          for (const key of Object.keys(raw)) {
+            const group = raw[key]
+            if (group && typeof group === 'object' && Object.prototype.hasOwnProperty.call(group, eid)) {
+              this.subjectLabels.update(m => ({ ...m, [eid]: group[eid] }))
+              return
+            }
+          }
+        })
+      })
+    }
   }
 
   createGroup(): void {
@@ -97,6 +381,38 @@ export class PermissionManagerComponent implements OnChanges {
     })
   }
 
+  onMemberQueryChange(query: string): void {
+    if (query.length < 2) this.memberSuggestions.set([])
+    this.memberSearchInput$.next(query)
+  }
+
+  addGroupMember(groupId: string, label: string): void {
+    const peopleId = this.memberPeopleIndex[label]
+    if (!peopleId) return
+    setTimeout(() => { this.memberQuery = ''; this.memberSuggestions.set([]) })
+
+    const personUrl = (this.configSvc.getConfig<any>()['personURL'] ?? '') as string
+    const doAdd = (memberId: string) => {
+      this.groupsSvc.addMember(groupId, memberId).subscribe({
+        next: updatedMembers => {
+          this.groups.update(gs => gs.map(g =>
+            g.id === groupId ? { ...g, members: updatedMembers } : g
+          ))
+        },
+        error: err => console.error('[PermissionManager] addMember error:', err)
+      })
+    }
+
+    if (personUrl) {
+      this.http.get<any>(`${personUrl}${peopleId}`).subscribe({
+        next: person => doAdd(person?.nistUsername || peopleId),
+        error: () => doAdd(peopleId)
+      })
+    } else {
+      doAdd(peopleId)
+    }
+  }
+
   toggleGroup(id: string): void {
     this.expandedGroupId.update(cur => cur === id ? null : id)
   }
@@ -113,6 +429,7 @@ export class PermissionManagerComponent implements OnChanges {
       next: acls => {
         this.acls.set(acls)
         this.aclsLoading.set(false)
+        this.resolveUnknownLabels(acls)
       },
       error: err => {
         this.aclsError.set('Could not load permissions.')
@@ -126,12 +443,257 @@ export class PermissionManagerComponent implements OnChanges {
     return this.acls()?.[perm] ?? []
   }
 
-  revokePermission(perm: AclPerm, subject: string): void {
+  subjectLevel(subject: string): 'view' | 'update' | 'admin' | null {
+    const acls = this.acls()
+    if (!acls) return null
+    const r = acls.read?.includes(subject) ?? false
+    const w = acls.write?.includes(subject) ?? false
+    const a = acls.admin?.includes(subject) ?? false
+    const d = acls.delete?.includes(subject) ?? false
+    if (r && w && a && d) return 'admin'
+    if (r && w) return 'update'
+    if (r) return 'view'
+    return null
+  }
+
+  setSubjectLevel(subject: string, newLevel: 'view' | 'update' | 'admin'): void {
     const record = this.singleRecord()
     if (!record) return
-    this.permsSvc.revokePerm(record, perm, subject).subscribe({
-      next: updated => this.acls.set(updated),
-      error: err => console.error('[PermissionManager] revokePerm error:', err)
+    const current = this.acls()
+    if (!current) return
+
+    const required = this.LEVEL_PERMS[newLevel]
+    const all: AclPerm[] = ['read', 'write', 'admin', 'delete']
+    const toGrant = required.filter(p => !(current[p] ?? []).includes(subject))
+    const toRevoke = all.filter(p => !required.includes(p) && (current[p] ?? []).includes(subject))
+    const grantOps = toGrant.map(p => this.permsSvc.grantPerm(record, p, subject))
+    const revokeOps = toRevoke.map(p => this.permsSvc.revokePerm(record, p, subject))
+    const total = grantOps.length + revokeOps.length
+    if (!total) return
+
+    let remaining = total
+    const onNext = () => { if (--remaining === 0) { this.loadAcls(); this.permissionsChanged.emit() } }
+    const onError = (err: unknown) => console.error('[PermissionManager] setSubjectLevel error:', err)
+    grantOps.forEach(op$ => op$.subscribe({ next: onNext, error: onError }))
+    revokeOps.forEach(op$ => op$.subscribe({ next: onNext, error: onError }))
+  }
+
+  removeSubject(subject: string): void {
+    const record = this.singleRecord()
+    if (!record) return
+    const current = this.acls()
+    if (!current) return
+
+    const toRevoke: AclPerm[] = (['read', 'write', 'admin', 'delete'] as AclPerm[])
+      .filter(p => (current[p] ?? []).includes(subject))
+    if (!toRevoke.length) return
+
+    let remaining = toRevoke.length
+    toRevoke.forEach(p => {
+      this.permsSvc.revokePerm(record, p, subject).subscribe({
+        next: () => { if (--remaining === 0) { this.loadAcls(); this.permissionsChanged.emit() } },
+        error: err => console.error('[PermissionManager] removeSubject error:', err)
+      })
     })
   }
+
+  grantStagedLevel(level: 'view' | 'update' | 'admin'): void {
+    const record = this.singleRecord()
+    if (!record) return
+    const people = this.staged()
+    if (!people.length) return
+
+    people.forEach(person => this.setSubjectLevel(person.id, level))
+    this.closeAddPerson()
+  }
+
+  // ── Confirmation wrappers ─────────────────────────────────────────────────
+
+  private confirm(data: ConfirmDialogData, onConfirm: () => void): void {
+    this.dialog.open(ConfirmDialogComponent, { data, width: '420px' })
+      .afterClosed()
+      .subscribe(confirmed => { if (confirmed) onConfirm() })
+  }
+
+  confirmRemoveSubject(subject: string): void {
+    const label = this.subjectLabels()[subject] || subject
+    const record = this.singleRecord()
+    this.confirm({
+      title: 'Remove access',
+      body: `Remove all access for "${label}" on ${record?.id}?`,
+      confirmLabel: 'Remove',
+      isDestructive: true,
+    }, () => this.removeSubject(subject))
+  }
+
+  confirmSetLevel(subject: string, newLevel: 'view' | 'update' | 'admin'): void {
+    const label = this.subjectLabels()[subject] || subject
+    const record = this.singleRecord()
+    const current = this.subjectLevel(subject)
+    this.confirm({
+      title: 'Change access level',
+      body: `Change access for "${label}" on ${record?.id} from ${current ?? 'custom'} to ${newLevel}?`,
+      confirmLabel: 'Change',
+    }, () => this.setSubjectLevel(subject, newLevel))
+  }
+
+  confirmGrantLevel(level: 'view' | 'update' | 'admin'): void {
+    const record = this.singleRecord()
+    this.confirm({
+      title: `Grant ${level} access`,
+      body: `Grant ${level.toUpperCase()} access on ${record?.id} to:`,
+      items: this.staged().map(p => p.label),
+      confirmLabel: 'Grant',
+    }, () => this.grantStagedLevel(level))
+  }
+
+  confirmBulkGrant(): void {
+    const level = this.bulkLevel
+    this.confirm({
+      title: `Bulk grant ${level} access`,
+      body: `Grant ${level.toUpperCase()} access to:`,
+      items: this.staged().map(p => p.label),
+      section: `On ${this.records.length} record${this.records.length > 1 ? 's' : ''}:`,
+      sectionItems: this.records.map(r => r.id),
+      confirmLabel: `Grant to all ${this.records.length} records`,
+    }, () => this.grantBulk())
+  }
+
+  confirmDeleteGroup(groupId: string): void {
+    const group = this.groups().find(g => g.id === groupId)
+    const count = group?.members.length ?? 0
+    this.confirm({
+      title: 'Delete group',
+      body: `Permanently delete group "${group?.name}"?`,
+      items: count > 0
+        ? [`${count} member${count > 1 ? 's' : ''} will lose access granted through this group`]
+        : ['This group has no members'],
+      confirmLabel: 'Delete',
+      isDestructive: true,
+    }, () => this.deleteGroup(groupId))
+  }
+
+  // ── User's NIST org units ─────────────────────────────────────────────────
+
+  loadNistOrgs(ou: string): void {
+    const orgUrl = (this.configSvc.getConfig<any>()['orgURL'] ?? '') as string
+    if (!orgUrl || !ou) return
+    this.nistOrgsLoading.set(true)
+    this.http.get<any>(`${orgUrl}?${encodeURIComponent(ou.toUpperCase())}`).subscribe({
+      next: raw => {
+        const flat: { id: string; name: string; key: string }[] = []
+        if (raw && typeof raw === 'object') {
+          Object.keys(raw).forEach(key => {
+            const group = raw[key]
+            if (group && typeof group === 'object') {
+              Object.keys(group).forEach(id => flat.push({ id, name: group[id], key }))
+            }
+          })
+        }
+        const q = ou.toLowerCase()
+        const seen = new Set<string>()
+        const orgs = flat
+          .filter(o => o.name.toLowerCase().includes(q) || o.key.toLowerCase().includes(q))
+          .filter(o => !seen.has(o.id) && seen.add(o.id))
+          .map(o => ({ id: o.id, name: o.name }))
+        this.nistOrgs.set(orgs)
+        this.nistOrgsLoading.set(false)
+      },
+      error: () => { this.nistOrgs.set([]); this.nistOrgsLoading.set(false) }
+    })
+  }
+
+  stageNistOrg(org: { id: string; name: string }): void {
+    this._addStaged(org.id, org.name)
+  }
+
+  isNistOrgStaged(orgId: string): boolean {
+    return this.staged().some(s => s.id === orgId)
+  }
+
+  // ── People picker ─────────────────────────────────────────────────────────
+
+  openAddPerson(): void {
+    this.showAddPanel.set(true)
+    this.staged.set([])
+    this.grantLevelValue = 'update'
+    this.peopleQuery = ''
+    this.peopleSuggestions.set([])
+    this.groupQuery = ''
+    this.groupSuggestions.set([])
+  }
+
+  closeAddPerson(): void {
+    this.showAddPanel.set(false)
+    this.staged.set([])
+    this.peopleQuery = ''
+    this.peopleSuggestions.set([])
+    this.groupQuery = ''
+    this.groupSuggestions.set([])
+  }
+
+  onPeopleQueryChange(query: string): void {
+    if (query.length < 2) this.peopleSuggestions.set([])
+    this.searchInput$.next(query)
+  }
+
+  stagePerson(label: string): void {
+    const peopleId = this.peopleIndex[label]
+    if (!peopleId) return
+
+    // clear input immediately
+    setTimeout(() => {
+      this.peopleQuery = ''
+      this.peopleSuggestions.set([])
+    })
+
+    const personUrl = (this.configSvc.getConfig<any>()['personURL'] ?? '') as string
+    if (personUrl) {
+      this.http.get<any>(`${personUrl}${peopleId}`).subscribe({
+        next: person => {
+          const subject = person?.nistUsername || peopleId
+          this._addStaged(subject, label)
+        },
+        error: () => this._addStaged(peopleId, label)
+      })
+    } else {
+      this._addStaged(peopleId, label)
+    }
+  }
+
+  onGroupQueryChange(query: string): void {
+    if (query.length < 3) this.groupSuggestions.set([])
+    this.groupSearchInput$.next(query)
+  }
+
+  displayGroupLabel = (_: any): string => ''
+
+  stageGroupSuggestion(s: { id: string; name: string; type: string }): void {
+    this._addStaged(s.id, s.name)
+    setTimeout(() => {
+      this.groupQuery = ''
+      this.groupSuggestions.set([])
+    })
+  }
+
+  stageGroup(group: Group): void {
+    this._addStaged(group.id, group.name)
+  }
+
+  isGroupStaged(groupId: string): boolean {
+    return this.staged().some(s => s.id === groupId)
+  }
+
+  private _addStaged(subject: string, label: string): void {
+    if (!this.staged().find(p => p.id === subject)) {
+      this.staged.update(s => [...s, { id: subject, label }])
+      this.subjectLabels.update(m => ({ ...m, [subject]: label }))
+    }
+  }
+
+  unstage(id: string): void {
+    this.staged.update(s => s.filter(p => p.id !== id))
+  }
+
 }
+

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core'
-import { AclPerm } from '../group.types'
+import { AclPerm, RecordRef } from '../group.types'
 
 @Component({
   selector: 'oarng-permission-manager',
@@ -7,8 +7,8 @@ import { AclPerm } from '../group.types'
   styleUrl: './permission-manager.component.scss'
 })
 export class PermissionManagerComponent {
-  @Input() recordId: string = ''
-  @Input() apiBase: string = ''
+  @Input() records: RecordRef[] = []
+  @Input() layout: 'compact' | 'panel' = 'compact'
 
   readonly perms: AclPerm[] = ['read', 'write', 'admin', 'delete']
 }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -41,6 +41,12 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     admin:  ['read', 'write', 'admin', 'delete'],
   }
 
+  private readonly NIST_ORG_PREFIX: Record<string, string> = {
+    ou: 'nistou',
+    div: 'nistdiv',
+    grp: 'nistgrp',
+  }
+
   // ── Groups state ──────────────────────────────────────────────────────────
   groups = signal<Group[]>([])
   groupsLoading = signal(false)
@@ -160,10 +166,10 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
               Object.keys(raw).forEach(key => {
                 const group = raw[key]
                 if (group && typeof group === 'object') {
-                  Object.keys(group).forEach(id => {
-                    // key.startsWith(q) handles org codes like MML, ITL; wordPrefixMatch handles names
-                    if (key.toLowerCase().startsWith(q) || wordPrefixMatch(group[id])) {
-                      nist.push({ id, name: group[id], type: 'nist' })
+                  Object.keys(group).forEach(numericId => {
+                    if (key.toLowerCase().startsWith(q) || wordPrefixMatch(group[numericId])) {
+                      const prefix = this.NIST_ORG_PREFIX[key] ?? key
+                      nist.push({ id: `${prefix}:${numericId}`, name: group[numericId], type: 'nist' })
                     }
                   })
                 }
@@ -216,8 +222,9 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       this.singleRecord.set(this.records.length === 1 ? this.records[0] : null)
       this.loadGroups()
       this.loadAcls()
-    }
-    if (changes['section'] && this.section === 'groups') {
+    } else if (changes['section'] && this.section === 'groups') {
+      // Only load groups when section changes to 'groups' and records didn't also change —
+      // if records changed, loadGroups was already called above.
       this.loadGroups()
     }
     if (changes['userOu'] && this.userOu) {
@@ -562,7 +569,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const current = this.subjectLevel(subject)
     this.confirm({
       title: 'Change access level',
-      body: `Change access for "${label}" on ${record?.id} from ${current ?? 'custom'} to ${newLevel}?`,
+      body: `Change access for "${label}" on ${record?.id} from ${current ?? 'none'} to ${newLevel}?`,
       confirmLabel: 'Change',
     }, () => this.setSubjectLevel(subject, newLevel))
   }
@@ -616,7 +623,10 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           Object.keys(raw).forEach(key => {
             const group = raw[key]
             if (group && typeof group === 'object') {
-              Object.keys(group).forEach(id => flat.push({ id, name: group[id], key }))
+              Object.keys(group).forEach(numericId => {
+                const prefix = this.NIST_ORG_PREFIX[key] ?? key
+                flat.push({ id: `${prefix}:${numericId}`, name: group[numericId], key })
+              })
             }
           })
         }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -467,8 +467,8 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const w = acls.write?.includes(subject) ?? false
     const a = acls.admin?.includes(subject) ?? false
     const d = acls.delete?.includes(subject) ?? false
-    if (r && w && a && d) return 'admin'
-    if (r && w) return 'update'
+    if (a) return 'admin'
+    if (w) return 'update'
     if (r) return 'view'
     return null
   }

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -230,41 +230,37 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     const level = this.bulkLevel
     if (!people.length || !this.records.length) return
 
-    const permsToGrant = this.LEVEL_PERMS[level]
+    const required = this.LEVEL_PERMS[level]
+    const all: AclPerm[] = ['read', 'write', 'admin', 'delete']
+    const toRevoke = all.filter(p => !required.includes(p))
     this.bulkGranting.set(true)
     this.bulkGrantError.set(null)
 
-    let remaining = people.length * this.records.length * permsToGrant.length
-    let failed = 0
+    const ops: Observable<unknown>[] = people.flatMap(person =>
+      this.records.flatMap(record => [
+        ...required.map(perm => this.permsSvc.grantPerm(record, perm, person.id)),
+        // Revoke perms above the target level; 404s are safe (subject didn't hold that perm).
+        ...toRevoke.map(p =>
+          this.permsSvc.revokePerm(record, p, person.id).pipe(catchError(() => of(null)))
+        ),
+      ])
+    )
 
-    people.forEach(person => {
-      this.records.forEach(record => {
-        permsToGrant.forEach(perm => {
-          this.permsSvc.grantPerm(record, perm, person.id).subscribe({
-            next: () => {
-              if (--remaining === 0) {
-                this.bulkGranting.set(false)
-                if (failed === 0) {
-                  this.staged.set([])
-                  this.peopleQuery = ''
-                  this.groupQuery = ''
-                  this.peopleSuggestions.set([])
-                  this.groupSuggestions.set([])
-                  this.permissionsChanged.emit()
-                }
-              }
-            },
-            error: err => {
-              failed++
-              if (--remaining === 0) {
-                this.bulkGranting.set(false)
-                this.bulkGrantError.set(`${failed} operation(s) failed.`)
-              }
-              console.error('[PermissionManager] bulk grant error:', err)
-            }
-          })
-        })
-      })
+    forkJoin(ops).subscribe({
+      next: () => {
+        this.bulkGranting.set(false)
+        this.staged.set([])
+        this.peopleQuery = ''
+        this.groupQuery = ''
+        this.peopleSuggestions.set([])
+        this.groupSuggestions.set([])
+        this.permissionsChanged.emit()
+      },
+      error: (err) => {
+        this.bulkGranting.set(false)
+        this.bulkGrantError.set('One or more operations failed.')
+        console.error('[PermissionManager] bulk grant error:', err)
+      }
     })
   }
 

--- a/libs/oarng/src/lib/groups/permissions.service.spec.ts
+++ b/libs/oarng/src/lib/groups/permissions.service.spec.ts
@@ -1,0 +1,149 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { PermissionsService } from './permissions.service'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+import { RecordRef, Acls } from './group.types'
+
+const RECORD: RecordRef = { id: 'mdm1:0001', apiBase: 'https://api.example.com/midas/dmp/1.0' }
+const ACLS: Acls = { read: ['alice'], write: ['alice'], admin: ['alice'], delete: ['alice'] }
+const EMPTY_ACLS: Acls = { read: [], write: [], admin: [], delete: [] }
+
+describe('PermissionsService — URL construction and HTTP methods', () => {
+  let svc: PermissionsService
+  let http: HttpTestingController
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PermissionsService]
+    })
+    svc = TestBed.inject(PermissionsService)
+    http = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => http.verify())
+
+  describe('getAcls()', () => {
+    it('issues GET to {apiBase}/{id}/acls', () => {
+      svc.getAcls(RECORD).subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls')
+      expect(req.request.method).toBe('GET')
+      req.flush(ACLS)
+    })
+
+    it('strips trailing slash from apiBase', () => {
+      svc.getAcls({ ...RECORD, apiBase: 'https://api.example.com/midas/dmp/1.0/' }).subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls')
+      req.flush(ACLS)
+    })
+
+    it('does not set Authorization header when no token provider is given', () => {
+      svc.getAcls(RECORD).subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls')
+      expect(req.request.headers.has('Authorization')).toBe(false)
+      req.flush(ACLS)
+    })
+  })
+
+  describe('setAcls()', () => {
+    it('issues PUT to {apiBase}/{id}/acls with the full acls object', () => {
+      svc.setAcls(RECORD, ACLS).subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls')
+      expect(req.request.method).toBe('PUT')
+      expect(req.request.body).toEqual(ACLS)
+      req.flush(ACLS)
+    })
+  })
+
+  describe('grantPerm()', () => {
+    it('issues POST to .../acls/{perm}', () => {
+      svc.grantPerm(RECORD, 'read', 'alice').subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/read')
+      expect(req.request.method).toBe('POST')
+      req.flush(['alice'])
+    })
+
+    it('sends JSON-encoded subject string as body', () => {
+      svc.grantPerm(RECORD, 'read', 'alice').subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/read')
+      expect(req.request.body).toBe('"alice"')
+      req.flush(['alice'])
+    })
+
+    it('sets Content-Type: application/json', () => {
+      svc.grantPerm(RECORD, 'write', 'alice').subscribe()
+      const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/write')
+      expect(req.request.headers.get('Content-Type')).toBe('application/json')
+      req.flush(['alice'])
+    })
+
+    it('works for all four permission types', () => {
+      for (const perm of ['read', 'write', 'admin', 'delete'] as const) {
+        svc.grantPerm(RECORD, perm, 'alice').subscribe()
+        const req = http.expectOne(
+          `https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/${perm}`
+        )
+        req.flush(['alice'])
+      }
+    })
+  })
+
+  describe('revokePerm()', () => {
+    it('issues DELETE to .../acls/{perm}/{subject}', () => {
+      svc.revokePerm(RECORD, 'admin', 'alice').subscribe()
+      const req = http.expectOne(
+        'https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/admin/alice'
+      )
+      expect(req.request.method).toBe('DELETE')
+      req.flush(EMPTY_ACLS)
+    })
+
+    it('URL-encodes a subject containing colons (group ID)', () => {
+      svc.revokePerm(RECORD, 'read', 'grp0:alice:team').subscribe()
+      const req = http.expectOne(
+        'https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/read/grp0%3Aalice%3Ateam'
+      )
+      req.flush(EMPTY_ACLS)
+    })
+  })
+})
+
+describe('PermissionsService — Authorization header with token', () => {
+  let svc: PermissionsService
+  let http: HttpTestingController
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        PermissionsService,
+        { provide: GROUPS_AUTH_TOKEN, useValue: () => 'test-bearer-token' }
+      ]
+    })
+    svc = TestBed.inject(PermissionsService)
+    http = TestBed.inject(HttpTestingController)
+  })
+
+  afterEach(() => http.verify())
+
+  it('includes Authorization: Bearer {token} on GET requests', () => {
+    svc.getAcls(RECORD).subscribe()
+    const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls')
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-bearer-token')
+    req.flush(ACLS)
+  })
+
+  it('includes Authorization header on POST requests', () => {
+    svc.grantPerm(RECORD, 'read', 'alice').subscribe()
+    const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/read')
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-bearer-token')
+    req.flush(['alice'])
+  })
+
+  it('includes Authorization header on DELETE requests', () => {
+    svc.revokePerm(RECORD, 'read', 'alice').subscribe()
+    const req = http.expectOne('https://api.example.com/midas/dmp/1.0/mdm1:0001/acls/read/alice')
+    expect(req.request.headers.get('Authorization')).toBe('Bearer test-bearer-token')
+    req.flush(EMPTY_ACLS)
+  })
+})

--- a/libs/oarng/src/lib/groups/permissions.service.ts
+++ b/libs/oarng/src/lib/groups/permissions.service.ts
@@ -10,7 +10,9 @@ export class PermissionsService {
   private getToken = inject(GROUPS_AUTH_TOKEN, { optional: true }) ?? (() => '')
 
   private get headers(): HttpHeaders {
-    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+    const token = this.getToken()
+    const h = new HttpHeaders()
+    return token ? h.set('Authorization', `Bearer ${token}`) : h
   }
 
   // Backend: /{record.apiBase}/{record.id}/acls  (plural)
@@ -27,11 +29,11 @@ export class PermissionsService {
     return this.http.put<Acls>(this.aclsUrl(record), acls, { headers: this.headers })
   }
 
-  // POST /acls/{perm} — body is the subject string directly (or array)
-  grantPerm(record: RecordRef, perm: keyof Acls, subject: string): Observable<Acls> {
-    return this.http.post<Acls>(
+  // POST /acls/{perm} — backend expects a JSON-encoded string body
+  grantPerm(record: RecordRef, perm: keyof Acls, subject: string): Observable<string[]> {
+    return this.http.post<string[]>(
       `${this.aclsUrl(record)}/${perm}`,
-      subject,
+      JSON.stringify(subject),
       { headers: this.headers.set('Content-Type', 'application/json') }
     )
   }

--- a/libs/oarng/src/lib/groups/permissions.service.ts
+++ b/libs/oarng/src/lib/groups/permissions.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core'
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+import { Acls, RecordRef } from './group.types'
+
+@Injectable({ providedIn: 'root' })
+export class PermissionsService {
+  private http = inject(HttpClient)
+  private getToken = inject(GROUPS_AUTH_TOKEN, { optional: true }) ?? (() => '')
+
+  private get headers(): HttpHeaders {
+    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+  }
+
+  // Backend: /{record.apiBase}/{record.id}/acls  (plural)
+  private aclsUrl(record: RecordRef): string {
+    return `${record.apiBase.replace(/\/$/, '')}/${record.id}/acls`
+  }
+
+  getAcls(record: RecordRef): Observable<Acls> {
+    return this.http.get<Acls>(this.aclsUrl(record), { headers: this.headers })
+  }
+
+  // PUT /acls — bulk replace all permission lists at once
+  setAcls(record: RecordRef, acls: Acls): Observable<Acls> {
+    return this.http.put<Acls>(this.aclsUrl(record), acls, { headers: this.headers })
+  }
+
+  // POST /acls/{perm} — body is the subject string directly (or array)
+  grantPerm(record: RecordRef, perm: keyof Acls, subject: string): Observable<Acls> {
+    return this.http.post<Acls>(
+      `${this.aclsUrl(record)}/${perm}`,
+      subject,
+      { headers: this.headers.set('Content-Type', 'application/json') }
+    )
+  }
+
+  // DELETE /acls/{perm}/{subject}
+  revokePerm(record: RecordRef, perm: keyof Acls, subject: string): Observable<Acls> {
+    return this.http.delete<Acls>(
+      `${this.aclsUrl(record)}/${perm}/${encodeURIComponent(subject)}`,
+      { headers: this.headers }
+    )
+  }
+}

--- a/libs/oarng/src/lib/groups/permissions.service.ts
+++ b/libs/oarng/src/lib/groups/permissions.service.ts
@@ -10,7 +10,9 @@ export class PermissionsService {
   private getToken = inject(GROUPS_AUTH_TOKEN, { optional: true }) ?? (() => '')
 
   private get headers(): HttpHeaders {
-    return new HttpHeaders({ Authorization: `Bearer ${this.getToken()}` })
+    const token = this.getToken()
+    const h = new HttpHeaders()
+    return token ? h.set('Authorization', `Bearer ${token}`) : h
   }
 
   // Backend: /{record.apiBase}/{record.id}/acls  (plural)

--- a/libs/oarng/src/public-api.ts
+++ b/libs/oarng/src/public-api.ts
@@ -20,3 +20,7 @@ export * from './lib/staffdir/staffdir.module';
 export * from './lib/data/data.module';
 
 export * from './lib/frame/header/header-pub/header-pub.component';
+
+export * from './lib/groups/groups.module';
+export * from './lib/groups/group.types';
+export * from './lib/groups/permission-manager/permission-manager.component';

--- a/libs/oarng/src/public-api.ts
+++ b/libs/oarng/src/public-api.ts
@@ -23,4 +23,7 @@ export * from './lib/frame/header/header-pub/header-pub.component';
 
 export * from './lib/groups/groups.module';
 export * from './lib/groups/group.types';
+export * from './lib/groups/groups-auth.token';
+export * from './lib/groups/groups.service';
+export * from './lib/groups/permissions.service';
 export * from './lib/groups/permission-manager/permission-manager.component';

--- a/libs/oarng/tsconfig.spec.json
+++ b/libs/oarng/tsconfig.spec.json
@@ -5,6 +5,10 @@
     "outDir": "../../out-tsc/spec",
     "types": [
         "jest", "node"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../../node_modules/@types"
     ]
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^18.2.13",
+    "@angular/cdk": "^18.2.13",
     "@angular/common": "^18.2.13",
     "@angular/compiler": "^18.2.13",
     "@angular/core": "^18.2.13",
     "@angular/forms": "^18.2.13",
+    "@angular/material": "^18.2.13",
     "@angular/platform-browser": "^18.2.13",
     "@angular/platform-browser-dynamic": "^18.2.13",
     "@angular/router": "^18.2.13",


### PR DESCRIPTION
This adds a new PermissionManagerComponent to the oarng library, allowing
users to manage access control on their MIDAS records (DMPs and DAPs) directly
from the portal.

The component handles three types of subjects: individual people (searched by
name via the NSD people API), MIDAS groups (user-created collections of people),
and NIST organizational units. It maps these to three permission levels: View,
Update, and Admin.

NIST org units deserve a special mention — the NSD stores them under several
different subject formats depending on how old the record is (nistdiv:13289,
775:13289, mml:13213 are all real examples we encountered). All three now
resolve to a human-readable label like "Software and Systems Division (775)".

The My Groups tab lets users create groups, see their members at a glance, add
or remove members, and delete groups. Deleting a group shows a confirmation
dialog that lists exactly who will lose access, so the action isn't blind.

The component is designed to be self-contained and reusable — the only
configuration it needs is four keys in the app's environment.json (groupAPI,
peopleURL, personURL, orgURL), an optional GROUPS_AUTH_TOKEN injection token
for bearer auth, and a record reference to work against.