### PR TITLE
Time out the auth token check and fall back to login

### DIFF
--- a/libs/oarng/src/lib/auth/auth.service.ts
+++ b/libs/oarng/src/lib/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, of, map, tap, switchMap, catchError, throwError, Subscriber, EMPTY, BehaviorSubject } from 'rxjs';
+import { Observable, of, map, tap, switchMap, catchError, throwError, Subscriber, EMPTY, BehaviorSubject, timeout, TimeoutError } from 'rxjs';
 
 import { AuthInfo, UserDetails, Credentials, MOCK_CREDENTIALS, messageToCredentials, deepCopy } from './auth';
 import { Configuration, ConfigurationService } from '../config/config.module';
@@ -224,6 +224,11 @@ export class OARAuthenticationService extends AuthenticationService {
                 return of(c);
             }),
             catchError((e) => {
+                // A stalled auth check (e.g. Safari) times out here; treat it like "not logged in".
+                if (e instanceof TimeoutError) {
+                    console.warn("tokeninfo timed out; redirecting to login");
+                    return this.handleUnauthenticated(!nologin, returnURL);
+                }
                 console.error("Credentials not available (status = "+e.status+")");
                 if (e.status && e.status == 401)
                     return this.handleUnauthenticated(!nologin, returnURL);
@@ -245,6 +250,9 @@ export class OARAuthenticationService extends AuthenticationService {
         url += "auth/_tokeninfo";
 
         return this.httpcli.get(url).pipe(
+            // Cap the auth check: Safari can stall this request indefinitely; on timeout,
+            // catchError() falls back to login instead of hanging.
+            timeout(5000),
             map<any, Credentials>(messageToCredentials)
         );
     }


### PR DESCRIPTION
This PR fixes #42.

**Issue:** in Safari, the RPA approve page hangs on "Processing…". The initial `GET /sso/auth/_tokeninfo` never completes (401 from proxy received but not finalized) and the request has no effective timeout, so the app waits indefinitely and never redirects to login. Chrome/Firefox works fine.

**Fix:** I added a **5s timeout()** on the `_tokeninfo` call in `AuthenticationService`; on `TimeoutError`, fall back to the existing login redirect (same path as unauthenticated).

How to test:
- Safari: open an approve link; before, spins on "Processing…" forever; after, redirects to login within 5s.
- Chrome/Firefox: unchanged (timeout never fires).
- Verified via a hotfix build on testdata.

**Notes:** Branched off `1.2.5rc1` (the deployed commit); `auth.service.ts` is identical on `integration` branch, so it should merge without conflict.