### PR TITLE
feat(oarng): permission manager dialog, centralized NSD service, and staff name resolution

### DIFF
--- a/libs/oarng/src/lib/groups/nsd.service.spec.ts
+++ b/libs/oarng/src/lib/groups/nsd.service.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing'
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing'
+import { NsdService } from './nsd.service'
+import { ConfigurationService } from '../config/config.service'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+
+const CONFIG = { staffdir: { serviceEndpoint: 'https://nsd.example.com/oar1' } }
+
+describe('NsdService', () => {
+  let svc: NsdService
+  let httpMock: HttpTestingController
+
+  describe('with an auth token', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          { provide: ConfigurationService, useValue: { getConfig: () => CONFIG } },
+          { provide: GROUPS_AUTH_TOKEN, useValue: () => 'tok123' },
+        ]
+      })
+      svc = TestBed.inject(NsdService)
+      httpMock = TestBed.inject(HttpTestingController)
+    })
+
+    afterEach(() => httpMock.verify())
+
+    it('getPeopleByUsername queries with_nistUsername with the bearer token', () => {
+      svc.getPeopleByUsername('cnd7').subscribe()
+
+      const req = httpMock.expectOne('https://nsd.example.com/oar1/people?with_nistUsername=cnd7')
+      expect(req.request.method).toBe('GET')
+      expect(req.request.headers.get('Authorization')).toBe('Bearer tok123')
+      req.flush([])
+    })
+
+    it('getPeopleByUsername URL-encodes the username', () => {
+      svc.getPeopleByUsername('a b').subscribe()
+
+      const req = httpMock.expectOne('https://nsd.example.com/oar1/people?with_nistUsername=a%20b')
+      req.flush([])
+    })
+
+    it('searchPeople uppercases the query against the index endpoint', () => {
+      svc.searchPeople('davis').subscribe()
+
+      const req = httpMock.expectOne('https://nsd.example.com/oar1/people/index?DAVIS')
+      expect(req.request.headers.get('Authorization')).toBe('Bearer tok123')
+      req.flush({})
+    })
+  })
+
+  describe('without an auth token', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [HttpClientTestingModule],
+        providers: [
+          { provide: ConfigurationService, useValue: { getConfig: () => CONFIG } },
+        ]
+      })
+      svc = TestBed.inject(NsdService)
+      httpMock = TestBed.inject(HttpTestingController)
+    })
+
+    afterEach(() => httpMock.verify())
+
+    it('getPeopleByUsername sends no Authorization header', () => {
+      svc.getPeopleByUsername('cnd7').subscribe()
+
+      const req = httpMock.expectOne('https://nsd.example.com/oar1/people?with_nistUsername=cnd7')
+      expect(req.request.headers.has('Authorization')).toBe(false)
+      req.flush([])
+    })
+  })
+})

--- a/libs/oarng/src/lib/groups/nsd.service.ts
+++ b/libs/oarng/src/lib/groups/nsd.service.ts
@@ -40,4 +40,13 @@ export class NsdService {
       { headers: this.headers() }
     )
   }
+
+  // The with_ filter is a substring match on the backend, so callers must
+  // still check nistUsername on the returned records for an exact match.
+  getPeopleByUsername(eid: string): Observable<any[]> {
+    return this.http.get<any[]>(
+      `${this.base}people?with_nistUsername=${encodeURIComponent(eid)}`,
+      { headers: this.headers() }
+    )
+  }
 }

--- a/libs/oarng/src/lib/groups/nsd.service.ts
+++ b/libs/oarng/src/lib/groups/nsd.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, inject } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { ConfigurationService } from '../config/config.service'
+import { GROUPS_AUTH_TOKEN } from './groups-auth.token'
+
+@Injectable({ providedIn: 'root' })
+export class NsdService {
+  private http = inject(HttpClient)
+  private configSvc = inject(ConfigurationService)
+  private getToken = inject(GROUPS_AUTH_TOKEN, { optional: true }) ?? (() => '')
+
+  private get base(): string {
+    const endpoint = (this.configSvc.getConfig<any>().staffdir?.serviceEndpoint ?? '') as string
+    return endpoint.replace(/\/?$/, '/')
+  }
+
+  private headers(): { [key: string]: string } {
+    const token = this.getToken()
+    return token ? { Authorization: `Bearer ${token}` } : {}
+  }
+
+  searchPeople(query: string): Observable<any> {
+    return this.http.get<any>(
+      `${this.base}people/index?${encodeURIComponent(query.toUpperCase())}`,
+      { headers: this.headers() }
+    )
+  }
+
+  searchOrgIndex(endpoint: string, query?: string): Observable<any> {
+    const url = query
+      ? `${this.base}orgs/${endpoint}/index?${encodeURIComponent(query.toUpperCase())}`
+      : `${this.base}orgs/${endpoint}/index`
+    return this.http.get<any>(url, { headers: this.headers() })
+  }
+
+  getPerson(peopleId: string): Observable<any> {
+    return this.http.get<any>(
+      `${this.base}people/${peopleId}`,
+      { headers: this.headers() }
+    )
+  }
+}

--- a/libs/oarng/src/lib/groups/permission-manager-dialog/permission-manager-dialog.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager-dialog/permission-manager-dialog.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
+import { PermissionManagerDialogComponent, PermissionManagerDialogData } from './permission-manager-dialog.component'
+import { RecordRef } from '../group.types'
+import { GROUPS_AUTH_TOKEN } from '../groups-auth.token'
+
+const RECORD: RecordRef = { id: 'mdm1:0001', apiBase: 'https://api.example.com/midas/dmp/mdm1' }
+const DATA: PermissionManagerDialogData = { record: RECORD, title: 'Share my record' }
+
+describe('PermissionManagerDialogComponent', () => {
+  let fixture: ComponentFixture<PermissionManagerDialogComponent>
+  let component: PermissionManagerDialogComponent
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PermissionManagerDialogComponent, HttpClientTestingModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: DATA },
+        { provide: MatDialogRef, useValue: { close: jest.fn() } },
+        { provide: GROUPS_AUTH_TOKEN, useValue: () => 'test-token' }
+      ]
+    }).compileComponents()
+    fixture = TestBed.createComponent(PermissionManagerDialogComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('exposes the record as a single-element records array', () => {
+    expect(component.records).toEqual([RECORD])
+  })
+
+  it('renders the permission manager', () => {
+    const el = fixture.nativeElement.querySelector('oarng-permission-manager')
+    expect(el).toBeTruthy()
+  })
+})

--- a/libs/oarng/src/lib/groups/permission-manager-dialog/permission-manager-dialog.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager-dialog/permission-manager-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, inject } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog'
+import { MatButtonModule } from '@angular/material/button'
+import { GroupsModule } from '../groups.module'
+import { RecordRef } from '../group.types'
+
+export interface PermissionManagerDialogData {
+  record: RecordRef
+  title: string
+}
+
+@Component({
+  selector: 'oarng-permission-manager-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule, GroupsModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+    <mat-dialog-content>
+      <oarng-permission-manager [records]="records" />
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button [mat-dialog-close]="null" aria-label="Close share dialog">Close</button>
+    </mat-dialog-actions>
+  `,
+  styles: [`
+    mat-dialog-content { min-width: min(680px, 90vw); padding-top: 8px; }
+  `]
+})
+export class PermissionManagerDialogComponent {
+  readonly data = inject<PermissionManagerDialogData>(MAT_DIALOG_DATA)
+  readonly records: RecordRef[] = [this.data.record]
+}

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.spec.ts
@@ -808,6 +808,53 @@ describe('PermissionManagerComponent', () => {
     })
   })
 
+  // ── resolveUnknownLabels — EID resolution ─────────────────────────────────
+
+  describe('resolveUnknownLabels — EID resolution', () => {
+    // The with_nistUsername query is a substring match on the backend, so the
+    // component must keep only the record whose nistUsername equals the EID.
+    it('resolves an EID to "Last, First" from the exact nistUsername match', () => {
+      jest.spyOn((component as any).nsd, 'getPeopleByUsername').mockReturnValue(of([
+        { nistUsername: 'mchiang', lastName: 'Chiang', firstName: 'Martin' },
+        { nistUsername: 'mch', lastName: 'Hawes', firstName: 'Melvin' },
+        { nistUsername: 'pmchu', lastName: 'Chu', firstName: 'Pamela' },
+      ]))
+
+      ;(component as any).resolveUnknownLabels(makeAcls(['mch'], [], [], []))
+
+      expect(component.subjectLabels()['mch']).toBe('Hawes, Melvin')
+    })
+
+    it('leaves the label unset when no record matches the EID exactly', () => {
+      jest.spyOn((component as any).nsd, 'getPeopleByUsername').mockReturnValue(of([
+        { nistUsername: 'mchiang', lastName: 'Chiang', firstName: 'Martin' },
+      ]))
+
+      ;(component as any).resolveUnknownLabels(makeAcls(['mch'], [], [], []))
+
+      expect(component.subjectLabels()['mch']).toBeUndefined()
+    })
+
+    it('matches the EID case-insensitively and tolerates a missing firstName', () => {
+      jest.spyOn((component as any).nsd, 'getPeopleByUsername').mockReturnValue(of([
+        { nistUsername: 'CND7', lastName: 'Davis' },
+      ]))
+
+      ;(component as any).resolveUnknownLabels(makeAcls([], ['cnd7'], [], []))
+
+      expect(component.subjectLabels()['cnd7']).toBe('Davis')
+    })
+
+    it('does not query the people API for numeric org subjects', () => {
+      const spy = jest.spyOn((component as any).nsd, 'getPeopleByUsername')
+
+      ;(component as any).resolveUnknownLabels(makeAcls(['13252'], [], [], []))
+
+      expect(spy).not.toHaveBeenCalled()
+      expect(component.subjectLabels()['13252']).toBe('Org group (13252)')
+    })
+  })
+
   // ── ngOnChanges dedup ──────────────────────────────────────────────────────
 
   describe('ngOnChanges', () => {

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -332,19 +332,16 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       this.subjectLabels.update(m => ({ ...m, ...syncUpdates }))
     }
 
-    // EIDs: search the people API with the EID as query and look for an exact key match
+    // EIDs: query by nistUsername and keep only the exact match
     toResolveViaSearch.forEach(eid => {
-      this.nsd.searchPeople(eid).pipe(
-        catchError(() => of({}))
-      ).subscribe((raw: any) => {
-          if (!raw || typeof raw !== 'object') return
-          for (const key of Object.keys(raw)) {
-            const group = raw[key]
-            if (group && typeof group === 'object' && Object.prototype.hasOwnProperty.call(group, eid)) {
-              this.subjectLabels.update(m => ({ ...m, [eid]: group[eid] }))
-              return
-            }
-          }
+      this.nsd.getPeopleByUsername(eid).pipe(
+        catchError(() => of([]))
+      ).subscribe((people: any[]) => {
+          if (!Array.isArray(people)) return
+          const person = people.find(p => p?.nistUsername?.toLowerCase() === eid.toLowerCase())
+          if (!person?.lastName) return
+          const name = person.firstName ? `${person.lastName}, ${person.firstName}` : person.lastName
+          this.subjectLabels.update(m => ({ ...m, [eid]: name }))
         })
       })
 

--- a/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
+++ b/libs/oarng/src/lib/groups/permission-manager/permission-manager.component.ts
@@ -1,11 +1,10 @@
 import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, inject, signal, computed } from '@angular/core'
 import { Subject, Subscription, Observable, of, forkJoin } from 'rxjs'
 import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators'
-import { HttpClient } from '@angular/common/http'
 import { MatDialog } from '@angular/material/dialog'
 import { GroupsService } from '../groups.service'
 import { PermissionsService } from '../permissions.service'
-import { ConfigurationService } from '../../config/config.service'
+import { NsdService } from '../nsd.service'
 import { Group, RecordRef, Acls, AclPerm } from '../group.types'
 import { ConfirmDialogComponent, ConfirmDialogData } from '../confirm-dialog.component'
 
@@ -29,8 +28,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
 
   private groupsSvc = inject(GroupsService)
   private permsSvc = inject(PermissionsService)
-  private http = inject(HttpClient)
-  private configSvc = inject(ConfigurationService)
+  private nsd = inject(NsdService)
   private dialog = inject(MatDialog)
 
   // ── Graduated permission model ────────────────────────────────────────────
@@ -131,8 +129,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       switchMap(query => {
         if (query.length < 2) return of(null)
         this.peopleSearchLoading.set(true)
-        const baseUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
-        return this.http.get<any>(`${baseUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
+        return this.nsd.searchPeople(query).pipe(
           map(raw => ({ raw, query })),
           catchError(() => of(null))
         )
@@ -171,11 +168,9 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           .filter(g => wordPrefixMatch(g.name) || g.id.toLowerCase().startsWith(q))
           .slice(0, 5)
           .map(g => ({ id: g.id, name: g.name, code: '', type: 'midas' as const }))
-        const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
-        if (!orgBaseUrl) return of(midas)
         return forkJoin(
           this.NIST_ORG_TYPES.map(({ endpoint, prefix }) =>
-            this.http.get<any>(`${orgBaseUrl}/${endpoint}/index?${encodeURIComponent(query.toUpperCase())}`).pipe(
+            this.nsd.searchOrgIndex(endpoint, query).pipe(
               map(raw => this.parseOrgIndex(raw, prefix).filter(o => wordPrefixMatch(o.name))),
               catchError(() => of([]))
             )
@@ -192,8 +187,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       switchMap(query => {
         if (query.length < 2) return of(null)
         this.memberSearchLoading.set(true)
-        const baseUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
-        return this.http.get<any>(`${baseUrl}?${encodeURIComponent(query.toUpperCase())}`).pipe(
+        return this.nsd.searchPeople(query).pipe(
           map(raw => ({ raw, query })),
           catchError(() => of(null))
         )
@@ -339,12 +333,10 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     }
 
     // EIDs: search the people API with the EID as query and look for an exact key match
-    const peopleUrl = (this.configSvc.getConfig<any>()['peopleURL'] ?? '') as string
-    if (peopleUrl) {
-      toResolveViaSearch.forEach(eid => {
-        this.http.get<any>(`${peopleUrl}?${encodeURIComponent(eid.toUpperCase())}`).pipe(
-          catchError(() => of({}))
-        ).subscribe((raw: any) => {
+    toResolveViaSearch.forEach(eid => {
+      this.nsd.searchPeople(eid).pipe(
+        catchError(() => of({}))
+      ).subscribe((raw: any) => {
           if (!raw || typeof raw !== 'object') return
           for (const key of Object.keys(raw)) {
             const group = raw[key]
@@ -355,24 +347,21 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           }
         })
       })
-    }
 
     // NIST org subjects — two formats:
     //   new: "nistou:13289" / "nistdiv:13289" / "nistgrp:13289"
     //   legacy: "775:13289" (orgCode:orgId, stored by older versions of this UI)
     // In both cases, display as "{orgName} ({orgCode})".
-    const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
-    if (orgBaseUrl) {
-      toResolveViaOrg.forEach(subject => {
-        const colonIdx = subject.indexOf(':')
-        const prefix = subject.substring(0, colonIdx)
-        const afterColon = subject.substring(colonIdx + 1)
+    toResolveViaOrg.forEach(subject => {
+      const colonIdx = subject.indexOf(':')
+      const prefix = subject.substring(0, colonIdx)
+      const afterColon = subject.substring(colonIdx + 1)
 
-        if (/^nist(ou|div|grp)$/.test(prefix)) {
-          // New format: query the typed endpoint, look up numericId directly
-          const mapping = this.ORG_TYPE_MAP[prefix]
-          this.http.get<any>(`${orgBaseUrl}/${mapping.endpoint}/index`).pipe(
-            catchError(() => of({}))
+      if (/^nist(ou|div|grp)$/.test(prefix)) {
+        // New format: query the typed endpoint, look up numericId directly
+        const mapping = this.ORG_TYPE_MAP[prefix]
+        this.nsd.searchOrgIndex(mapping.endpoint).pipe(
+          catchError(() => of({}))
           ).subscribe((raw: any) => {
             const numericId = afterColon
             for (const code of Object.keys(raw ?? {})) {
@@ -390,9 +379,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           const orgId = afterColon
           forkJoin(
             this.NIST_ORG_TYPES.map(({ endpoint }) =>
-              this.http.get<any>(`${orgBaseUrl}/${endpoint}/index`).pipe(
-                catchError(() => of({}))
-              )
+              this.nsd.searchOrgIndex(endpoint).pipe(catchError(() => of({})))
             )
           ).subscribe(responses => {
             for (const raw of responses) {
@@ -409,9 +396,7 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           const orgId = afterColon
           forkJoin(
             this.NIST_ORG_TYPES.map(({ endpoint }) =>
-              this.http.get<any>(`${orgBaseUrl}/${endpoint}/index`).pipe(
-                catchError(() => of({}))
-              )
+              this.nsd.searchOrgIndex(endpoint).pipe(catchError(() => of({})))
             )
           ).subscribe(responses => {
             for (const raw of responses) {
@@ -427,7 +412,6 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
           })
         }
       })
-    }
   }
 
   createGroup(): void {
@@ -479,7 +463,6 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
     if (!peopleId) return
     setTimeout(() => { this.memberQuery = ''; this.memberSuggestions.set([]) })
 
-    const personUrl = (this.configSvc.getConfig<any>()['personURL'] ?? '') as string
     const doAdd = (memberId: string) => {
       this.groupsSvc.addMember(groupId, memberId).subscribe({
         next: updatedMembers => {
@@ -491,14 +474,10 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       })
     }
 
-    if (personUrl) {
-      this.http.get<any>(`${personUrl}${peopleId}`).subscribe({
-        next: person => doAdd(person?.nistUsername || peopleId),
-        error: () => doAdd(peopleId)
-      })
-    } else {
-      doAdd(peopleId)
-    }
+    this.nsd.getPerson(peopleId).subscribe({
+      next: person => doAdd(person?.nistUsername || peopleId),
+      error: () => doAdd(peopleId)
+    })
   }
 
   toggleGroup(id: string): void {
@@ -723,12 +702,11 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
   // ── User's NIST org units ─────────────────────────────────────────────────
 
   loadNistOrgs(ou: string): void {
-    const orgBaseUrl = ((this.configSvc.getConfig<any>()['orgURL'] ?? '') as string).replace(/\/index$/, '')
-    if (!orgBaseUrl || !ou) return
+    if (!ou) return
     this.nistOrgsLoading.set(true)
     forkJoin(
       this.NIST_ORG_TYPES.map(({ endpoint, prefix }) =>
-        this.http.get<any>(`${orgBaseUrl}/${endpoint}/index?${encodeURIComponent(ou.toUpperCase())}`).pipe(
+        this.nsd.searchOrgIndex(endpoint, ou).pipe(
           map(raw => this.parseOrgIndex(raw, prefix)),
           catchError(() => of([]))
         )
@@ -819,18 +797,10 @@ export class PermissionManagerComponent implements OnChanges, OnDestroy {
       this.peopleSuggestions.set([])
     })
 
-    const personUrl = ((this.configSvc.getConfig<any>()['personURL'] ?? '') as string).replace(/\/?$/, '/')
-    if (personUrl !== '/') {
-      this.http.get<any>(`${personUrl}${peopleId}`).subscribe({
-        next: person => {
-          const subject = person?.nistUsername || peopleId
-          this._addStaged(subject, label)
-        },
-        error: () => this._addStaged(peopleId, label)
-      })
-    } else {
-      this._addStaged(peopleId, label)
-    }
+    this.nsd.getPerson(peopleId).subscribe({
+      next: person => this._addStaged(person?.nistUsername || peopleId, label),
+      error: () => this._addStaged(peopleId, label)
+    })
   }
 
   onGroupQueryChange(query: string): void {

--- a/libs/oarng/src/public-api.ts
+++ b/libs/oarng/src/public-api.ts
@@ -27,3 +27,4 @@ export * from './lib/groups/groups-auth.token';
 export * from './lib/groups/groups.service';
 export * from './lib/groups/permissions.service';
 export * from './lib/groups/permission-manager/permission-manager.component';
+export * from './lib/groups/permission-manager-dialog/permission-manager-dialog.component';

--- a/libs/oarng/src/public-api.ts
+++ b/libs/oarng/src/public-api.ts
@@ -26,5 +26,6 @@ export * from './lib/groups/group.types';
 export * from './lib/groups/groups-auth.token';
 export * from './lib/groups/groups.service';
 export * from './lib/groups/permissions.service';
+export * from './lib/groups/nsd.service';
 export * from './lib/groups/permission-manager/permission-manager.component';
 export * from './lib/groups/permission-manager-dialog/permission-manager-dialog.component';


### PR DESCRIPTION
1-  PermissionManagerDialogComponent — standalone MatDialog wrapper around the permission manager widget for the single-record share flow (used by the DMP editor). Accepts a record ref, a title, and an optional portal link.

2- NsdService — new service centralizing NSD calls (people search, org indexes, person lookup). Configured by a single staffdir.serviceEndpoint key, replacing the three flat URL keys (peopleURL, orgURL, personURL). Attaches the session bearer token when the host app provides one via GROUPS_AUTH_TOKEN; apps without a token provider keep working.

3- Staff name resolution  — ACL subject IDs (e.g. cnd7) stayed unresolved after a page reload. The previous lookup queried people/index?<ID>, but that endpoint returns a name-prefix index keyed by last name with numeric people IDs, so usernames never appear in it. Resolution now queries people?with_nistUsername=<id>; because that filter is a substring match server-side, only the record whose nistUsername matches exactly is used.

4- Portal hint — new optional groupsPortalUrl input on the widget; when set, a "To manage your groups go to the portal" link is shown under the group search. Hidden by default, so the portal app is unaffected.